### PR TITLE
upgrade mean of rotations to new LinearAlgebra syntax

### DIFF
--- a/src/euler_types.jl
+++ b/src/euler_types.jl
@@ -14,7 +14,7 @@ for axis in [:X, :Y, :Z]
     @eval begin
         struct $RotType{T} <: Rotation{3,T}
             theta::T
-            $RotType{T}(theta) where {T} = new{T}(theta)
+            $RotType{T}(theta::Real) where {T} = new{T}(theta)
             $RotType{T}(r::$RotType) where {T} = new{T}(r.theta)
         end
 

--- a/src/euler_types.jl
+++ b/src/euler_types.jl
@@ -14,7 +14,7 @@ for axis in [:X, :Y, :Z]
     @eval begin
         struct $RotType{T} <: Rotation{3,T}
             theta::T
-            $RotType{T}(theta::Real) where {T} = new{T}(theta)
+            $RotType{T}(theta) where {T} = new{T}(theta)
             $RotType{T}(r::$RotType) where {T} = new{T}(r.theta)
         end
 

--- a/src/mean.jl
+++ b/src/mean.jl
@@ -37,8 +37,8 @@ function Statistics.mean(qvec::AbstractVector{Quat{T}}, method::Integer = 0) whe
             Qi = @SVector [q.w, q.x, q.y, q.z]  # convert types to ensure we don't get quaternion multiplication
             M .+= Qi * (Qi')
         end
-        evec = eigfact(Symmetric(M), 4:4)
-        Qbar = Quat(evec.vectors[1], evec.vectors[2], evec.vectors[3], evec.vectors[4]) # This will renormalize the quaternion...
+        vectors = eigvecs(Symmetric(M))
+        Qbar = Quat(vectors[1], vectors[2], vectors[3], vectors[4]) # This will renormalize the quaternion...
     #else
     #    error("I haven't coded this")
     #end
@@ -47,5 +47,5 @@ function Statistics.mean(qvec::AbstractVector{Quat{T}}, method::Integer = 0) whe
 end
 
 function Statistics.mean(vec::AbstractVector{R}) where R<:Rotation
-    R(mean(convert(Vector{Quat{eltype(R)}}, vec)))
+    R(Statistics.mean(convert(Vector{Quat{eltype(R)}}, vec)))
 end

--- a/src/mean.jl
+++ b/src/mean.jl
@@ -37,8 +37,8 @@ function Statistics.mean(qvec::AbstractVector{Quat{T}}, method::Integer = 0) whe
             Qi = @SVector [q.w, q.x, q.y, q.z]  # convert types to ensure we don't get quaternion multiplication
             M .+= Qi * (Qi')
         end
-        vectors = eigvecs(Symmetric(M))
-        Qbar = Quat(vectors[1], vectors[2], vectors[3], vectors[4]) # This will renormalize the quaternion...
+        evec = eigfact(Symmetric(M), 4:4)
+        Qbar = Quat(evec.vectors[1], evec.vectors[2], evec.vectors[3], evec.vectors[4]) # This will renormalize the quaternion...
     #else
     #    error("I haven't coded this")
     #end
@@ -47,5 +47,5 @@ function Statistics.mean(qvec::AbstractVector{Quat{T}}, method::Integer = 0) whe
 end
 
 function Statistics.mean(vec::AbstractVector{R}) where R<:Rotation
-    R(Statistics.mean(convert(Vector{Quat{eltype(R)}}, vec)))
+    R(mean(convert(Vector{Quat{eltype(R)}}, vec)))
 end

--- a/src/mean.jl
+++ b/src/mean.jl
@@ -37,7 +37,7 @@ function Statistics.mean(qvec::AbstractVector{Quat{T}}, method::Integer = 0) whe
             Qi = @SVector [q.w, q.x, q.y, q.z]  # convert types to ensure we don't get quaternion multiplication
             M .+= Qi * (Qi')
         end
-        vectors = eigvecs(Symmetric(M))
+        vectors = eigvecs(Symmetric(M))[:, 4]
         Qbar = Quat(vectors[1], vectors[2], vectors[3], vectors[4]) # This will renormalize the quaternion...
     #else
     #    error("I haven't coded this")


### PR DESCRIPTION
mean was complaining about no eigfact function existing. This PR updates to current LinearAlgebra syntax which is eigvecs.