### PR TITLE
Rename RodriguesVec -> RotationVec

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ q5 = q3 \ q2  # q5 = inv(q3) * q2
 # convert to a Stereographic quaternion projection (recommended for applications with differentiation)
 spq = SPQuat(r)
 
-# convert to the Angle-axis parameterization, or related Rodrigues vector
+# convert to the Angle-axis parameterization, or related Rotation vector
 aa = AngleAxis(r)
-rv = RodriguesVec(r)
+rv = RotationVec(r)
 ϕ = rotation_angle(r)
 v = rotation_axis(r)
 
@@ -149,7 +149,7 @@ j2 = Rotations.jacobian(q, p) # How does the rotated point q*p change w.r.t. the
     they follow the same multiplicative *algebra* as quaternions, it is better
     to think of `Quat` as a 3×3 matrix rather than as a quaternion *number*.
 
-4. **Rodrigues Vector** `RodriguesVec{T}`
+4. **Rotation Vector** `RotationVec{T}`
 
     A 3D rotation encoded by an angle-axis representation as `angle * axis`.
     This type is used in packages such as [OpenCV](http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html#void%20Rodrigues%28InputArray%20src,%20OutputArray%20dst,%20OutputArray%20jacobian%29).
@@ -165,12 +165,12 @@ j2 = Rotations.jacobian(q, p) # How does the rotated point q*p change w.r.t. the
     A 3D rotation encoded by the stereographic projection of a unit quaternion.  This projection can be visualized as a pin hole camera, with the pin hole matching the quaternion `[-1,0,0,0]` and the image plane containing the origin and having normal direction `[1,0,0,0]`.  The "null rotation" `Quaternion(1.0,0,0,0)` then maps to the `SPQuat(0,0,0)`
 
     These are similar to the Rodrigues vector in that the axis direction is stored in an unnormalized form, and the rotation angle is encoded in the length of the axis.  This type has the nice property that the derivatives of the rotation matrix w.r.t. the `SPQuat` parameters are rational functions, making the `SPQuat` type a good choice for differentiation / optimization.
-    
+
 6. **Rodrigues Parameters** `RodriguesParam{T}`
-    A 3-parameter representation of 3D rotations that has a singularity at 180 degrees. They can be interpreted as a projection of the unit quaternion onto the plane tangent to the quaternion identity. They are computationally efficient and do not have a sign ambiguity. 
-    
+    A 3-parameter representation of 3D rotations that has a singularity at 180 degrees. They can be interpreted as a projection of the unit quaternion onto the plane tangent to the quaternion identity. They are computationally efficient and do not have a sign ambiguity.
+
 7. **Modified Rodrigues Parameter** `MRP{T}`
-    Equivalent to `SPQuat{T}`. Are frequently used in aerospace applications since they are a 3-parameter representation whose singularity happens at 360 degrees. In practice, the singularity can be avoided with some switching logic between one of two equivalent MRPs (obtained by projecting the negated quaternion). 
+    Equivalent to `SPQuat{T}`. Are frequently used in aerospace applications since they are a 3-parameter representation whose singularity happens at 360 degrees. In practice, the singularity can be avoided with some switching logic between one of two equivalent MRPs (obtained by projecting the negated quaternion).
 
 8. **Cardinal axis rotations** `RotX{T}`, `RotY{T}`, `RotZ{T}`
 
@@ -189,10 +189,10 @@ j2 = Rotations.jacobian(q, p) # How does the rotated point q*p change w.r.t. the
     such as `RotXYZ`, are said to follow the [**Tait Bryan**](https://en.wikipedia.org/wiki/Euler_angles#Tait.E2.80.93Bryan_angles) angle ordering,
     while those which repeat (e.g. `EulerXYX`) are said to use [**Proper Euler**](https://en.wikipedia.org/wiki/Euler_angles#Conventions) angle ordering.
 
-    Like the two-angle versions, the order of application to a vector is right-to-left, so that `RotXYZ(x, y, z) * v == RotX(x) * (RotY(y) * (RotZ(z) * v))`.  This may be interpreted as an "extrinsic" rotation about the Z, Y, and X axes or as an "intrinsic" rotation about the X, Y, and Z axes.  Similarly, `RotZYX(z, y, x)` may be interpreted as an "extrinsic" rotation about the X, Y, and Z axes or an "intrinsic" rotation about the Z, Y, and X axes. 
-    
+    Like the two-angle versions, the order of application to a vector is right-to-left, so that `RotXYZ(x, y, z) * v == RotX(x) * (RotY(y) * (RotZ(z) * v))`.  This may be interpreted as an "extrinsic" rotation about the Z, Y, and X axes or as an "intrinsic" rotation about the X, Y, and Z axes.  Similarly, `RotZYX(z, y, x)` may be interpreted as an "extrinsic" rotation about the X, Y, and Z axes or an "intrinsic" rotation about the Z, Y, and X axes.
+
 ### The Rotation Error state and Linearization
-It is often convenient to consider perturbations or errors about a particular 3D rotation, such as applications in state estimation or optimization-based control. Intuitively, we expect these errors to live in three-dimensional space. For globally non-singular parameterizations such as unit quaternions, we need a way to map between the four parameters of the quaternion to this three-dimensional plane tangent to the four-dimensional hypersphere on which quaternions live. 
+It is often convenient to consider perturbations or errors about a particular 3D rotation, such as applications in state estimation or optimization-based control. Intuitively, we expect these errors to live in three-dimensional space. For globally non-singular parameterizations such as unit quaternions, we need a way to map between the four parameters of the quaternion to this three-dimensional plane tangent to the four-dimensional hypersphere on which quaternions live.
 
 There are several of these maps provided by Rotations.jl:
 * `ExponentialMap`: A very common mapping that uses the quaternion

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -9,7 +9,7 @@ const suite = BenchmarkGroup()
 Random.seed!(1)
 
 noneuler = suite["Non-Euler conversions"] = BenchmarkGroup()
-rotationtypes = [RotMatrix3{T}, Quat{T}, UnitQuaternion{T}, SPQuat{T}, MRP{T}, AngleAxis{T}, RodriguesVec{T}]
+rotationtypes = [RotMatrix3{T}, Quat{T}, UnitQuaternion{T}, SPQuat{T}, MRP{T}, AngleAxis{T}, RotationVec{T}]
 for (from, to) in product(rotationtypes, rotationtypes)
     if from != to
         name = "$(string(from)) -> $(string(to))"

--- a/src/Rotations.jl
+++ b/src/Rotations.jl
@@ -22,12 +22,13 @@ include("rodrigues_params.jl")
 include("mrps.jl")
 include("error_maps.jl")
 include("rotation_error.jl")
+include("deprecated.jl")
 
 export
     Rotation, RotMatrix, RotMatrix2, RotMatrix3,
     Angle2d,
     Quat, SPQuat, UnitQuaternion,
-    AngleAxis, RodriguesVec, RodriguesParam, MRP,
+    AngleAxis, RodriguesVec, RotationVec, RodriguesParam, MRP,
     RotX, RotY, RotZ,
     RotXY, RotYX, RotZX, RotXZ, RotYZ, RotZY,
     RotXYX, RotYXY, RotZXZ, RotXZX, RotYZY, RotZYZ,

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -16,3 +16,12 @@ function Base.one(::Type{RodriguesVec{T}}) where T
     Base.depwarn("`one(::Type{RodriguesVec{T}})` is deprecated, use `one(::Type{RotationVec{T}})` instead.", :one)
     one(RotationVec{T})
 end
+function Base.rand(::Type{RodriguesVec})
+    Base.depwarn("`RodriguesVec` is deprecated, use `RotationVec` instead", :Type)
+    rand(RotationVec)
+end
+function Base.rand(::Type{RodriguesVec{T}}) where T
+    Base.depwarn("`RodriguesVec` is deprecated, use `RotationVec` instead", :Type)
+    rand(RotationVec{T})
+end
+

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,27 +1,3 @@
 
 # Deprecate RodriguesVec => RotationVec
-struct RodriguesVec{T} end
-@deprecate RodriguesVec(x, y, z) RotationVec(x, y, z)
-@deprecate RodriguesVec(t::NTuple{9}) RotationVec(t::NTuple{9})
-@deprecate RodriguesVec(r::Rotation) RotationVec(r::Rotation)
-function RodriguesVec{T}(x, y, z) where T
-    Base.depwarn("`RodriguesVec` is deprecated, use `RotationVec` instead", :Type)
-    RotationVec{T}(x,y,z)
-end
-function Base.one(::Type{RodriguesVec})
-    Base.depwarn("`one(::Type{RodriguesVec})` is deprecated, use `one(::Type{RotationVec})` instead.", :one)
-    one(RotationVec)
-end
-function Base.one(::Type{RodriguesVec{T}}) where T
-    Base.depwarn("`one(::Type{RodriguesVec{T}})` is deprecated, use `one(::Type{RotationVec{T}})` instead.", :one)
-    one(RotationVec{T})
-end
-function Base.rand(::Type{RodriguesVec})
-    Base.depwarn("`RodriguesVec` is deprecated, use `RotationVec` instead", :Type)
-    rand(RotationVec)
-end
-function Base.rand(::Type{RodriguesVec{T}}) where T
-    Base.depwarn("`RodriguesVec` is deprecated, use `RotationVec` instead", :Type)
-    rand(RotationVec{T})
-end
-
+Base.@deprecate_binding RodriguesVec RotationVec true

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,7 @@
+
+# Deprecate RodriguesVec => RotationVec
+abstract type RodriguesVec end
+@deprecate RodriguesVec(x, y, z) RotationVec(x, y, z)
+@deprecate RodriguesVec(t::NTuple{9}) RotationVec(t::NTuple{9})
+@deprecate RodriguesVec(r::Rotation) RotationVec(r::Rotation)
+# QUESTION: not sure how to deprecate Base.one(::Type{RodriguesVec})

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,7 +1,18 @@
 
 # Deprecate RodriguesVec => RotationVec
-abstract type RodriguesVec end
+struct RodriguesVec{T} end
 @deprecate RodriguesVec(x, y, z) RotationVec(x, y, z)
 @deprecate RodriguesVec(t::NTuple{9}) RotationVec(t::NTuple{9})
 @deprecate RodriguesVec(r::Rotation) RotationVec(r::Rotation)
-# QUESTION: not sure how to deprecate Base.one(::Type{RodriguesVec})
+function RodriguesVec{T}(x, y, z) where T
+    Base.depwarn("`RodriguesVec` is deprecated, use `RotationVec` instead", :Type)
+    RotationVec{T}(x,y,z)
+end
+function Base.one(::Type{RodriguesVec})
+    Base.depwarn("`one(::Type{RodriguesVec})` is deprecated, use `one(::Type{RotationVec})` instead.", :one)
+    one(RotationVec)
+end
+function Base.one(::Type{RodriguesVec{T}}) where T
+    Base.depwarn("`one(::Type{RodriguesVec{T}})` is deprecated, use `one(::Type{RotationVec{T}})` instead.", :one)
+    one(RotationVec{T})
+end

--- a/src/principal_value.jl
+++ b/src/principal_value.jl
@@ -13,7 +13,7 @@ the following properties:
 - all angles are between between `-pi` to `pi` (except for `AngleAxis` which is between `0` and `pi`).
 - all `Quat` have non-negative real part
 - the components of all `SPQuat` have a norm that is at most 1.
-- the `RodriguesVec` rotation is at most `pi`
+- the `RotationVec` rotation is at most `pi`
 
 """
 principal_value(r::RotMatrix) = r
@@ -52,11 +52,11 @@ function principal_value(aa::AngleAxis{T}) where {T}
     end
 end
 
-function principal_value(rv::RodriguesVec{T}) where {T}
+function principal_value(rv::RotationVec{T}) where {T}
     theta = rotation_angle(rv)
     if pi < theta
         re_s = rem2pi(theta, RoundNearest) / theta
-        return RodriguesVec(re_s * rv.sx, re_s * rv.sy, re_s * rv.sz)
+        return RotationVec(re_s * rv.sx, re_s * rv.sy, re_s * rv.sz)
     else
         return rv
     end

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -7,4 +7,6 @@
     @test_deprecated RodriguesVec{Float32}(1,2,3)
     @test_deprecated one(RodriguesVec)
     @test_deprecated one(RodriguesVec{Float64})
+    @test_deprecated rand(RodriguesVec)
+    @test_deprecated rand(RodriguesVec{Float64})
 end

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,12 +1,5 @@
 
 @testset "Deprecations" begin
     # RodriguesVec
-    @test_deprecated RodriguesVec(1,2,3)
-    @test_deprecated RodriguesVec(rand(UnitQuaternion))
-    @test_deprecated RodriguesVec(Tuple(rand(UnitQuaternion)))
-    @test_deprecated RodriguesVec{Float32}(1,2,3)
-    @test_deprecated one(RodriguesVec)
-    @test_deprecated one(RodriguesVec{Float64})
-    @test_deprecated rand(RodriguesVec)
-    @test_deprecated rand(RodriguesVec{Float64})
+    @test Base.isdeprecated(Rotations, :RodriguesVec)
 end

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,0 +1,4 @@
+
+@test_deprecated RodriguesVec(1,2,3)
+@test_deprecated RodriguesVec(rand(UnitQuaternion))
+@test_deprecated RodriguesVec(Tuple(rand(UnitQuaternion)))

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,4 +1,10 @@
 
-@test_deprecated RodriguesVec(1,2,3)
-@test_deprecated RodriguesVec(rand(UnitQuaternion))
-@test_deprecated RodriguesVec(Tuple(rand(UnitQuaternion)))
+@testset "Deprecations" begin
+    # RodriguesVec
+    @test_deprecated RodriguesVec(1,2,3)
+    @test_deprecated RodriguesVec(rand(UnitQuaternion))
+    @test_deprecated RodriguesVec(Tuple(rand(UnitQuaternion)))
+    @test_deprecated RodriguesVec{Float32}(1,2,3)
+    @test_deprecated one(RodriguesVec)
+    @test_deprecated one(RodriguesVec{Float64})
+end

--- a/test/principal_value_tests.jl
+++ b/test/principal_value_tests.jl
@@ -13,7 +13,7 @@ end
         qq = rand(Quat)
         qq_prin = principal_value(qq)
         @test 0.0 <= qq_prin.w
-        @test qq_prin ≈ qq        
+        @test qq_prin ≈ qq
     end
 end
 
@@ -22,25 +22,25 @@ end
         aa = AngleAxis(100.0 * randn(), randn(), randn(), randn())
         aa_prin = principal_value(aa)
         @test 0.0 <= aa_prin.theta
-        @test aa_prin ≈ aa        
+        @test aa_prin ≈ aa
     end
 end
 
-@testset "Principal Value (Rodrigues Vector)" begin
+@testset "Principal Value (Rotation Vector)" begin
     for i = 1:1000
-        rv = RodriguesVec(100.0 * randn(), 100.0 * randn(), 100.0 * randn())
+        rv = RotationVec(100.0 * randn(), 100.0 * randn(), 100.0 * randn())
         rv_prin = principal_value(rv)
         @test rotation_angle(rv_prin) <= pi
-        @test rv_prin ≈ rv        
+        @test rv_prin ≈ rv
     end
-    rv = RodriguesVec(0.0, 0.0, 0.0)
+    rv = RotationVec(0.0, 0.0, 0.0)
     rv_prin = principal_value(rv)
     @test rotation_angle(rv_prin) <= pi
-    @test rv_prin ≈ rv        
+    @test rv_prin ≈ rv
 end
 
 @testset "Principal Value ($(rot_type))" for rot_type in [:RotX, :RotY, :RotZ] begin
-        @eval begin 
+        @eval begin
             for i = 1:1000
                 r = $(rot_type)(100.0 * randn())
                 r_prin = principal_value(r)
@@ -52,7 +52,7 @@ end
 end
 
 @testset "Principal Value ($(rot_type))" for rot_type in [:RotXY, :RotYX, :RotZX, :RotXZ, :RotYZ, :RotZY] begin
-        @eval begin 
+        @eval begin
             for i = 1:1000
                 r = $rot_type(100.0 * randn(), 100.0 * randn())
                 r_prin = principal_value(r)
@@ -65,7 +65,7 @@ end
 end
 
 @testset "Principal Value ($(rot_type))" for rot_type in [:RotXYX, :RotYXY, :RotZXZ, :RotXZX, :RotYZY, :RotZYZ, :RotXYZ, :RotYXZ, :RotZXY, :RotXZY, :RotYZX, :RotZYX] begin
-        @eval begin 
+        @eval begin
             for i = 1:1000
                 r = $(rot_type)(100.0 * randn(), 100.0 * randn(), 100.0 * randn())
                 r_prin = principal_value(r)

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -65,7 +65,7 @@ end
 # build a full list of rotation types including the different angle ordering schemas
 #####################################################################################
 
-rot_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
+rot_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RotationVec,
 			 UnitQuaternion, RodriguesParam, MRP,
              RotXYZ, RotYZX, RotZXY, RotXZY, RotYXZ, RotZYX,
              RotXYX, RotYZY, RotZXZ, RotXZX, RotYXY, RotZYZ)
@@ -73,7 +73,7 @@ rot_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
 one_types = (RotX, RotY, RotZ)
 two_types = (RotXY, RotYZ, RotZX, RotXZ, RotYX, RotZY)
 taitbyran_types = (RotXYZ, RotYZX, RotZXY, RotXZY, RotYXZ, RotZYX)
-all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
+all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RotationVec,
 			 UnitQuaternion, RodriguesParam, MRP,
              RotXYZ, RotYZX, RotZXY, RotXZY, RotYXZ, RotZYX,
              RotXYX, RotYZY, RotZXZ, RotXZX, RotYXY, RotZYZ,


### PR DESCRIPTION
Per https://github.com/JuliaGeometry/Rotations.jl/issues/112#issuecomment-613166739 and the original discussion in https://github.com/JuliaGeometry/Rotations.jl/pull/113#issuecomment-604114831 this renames `RodriguesVec` to the more appropriate `RotationVec` that is more in line with the literature and avoids confusion with `RodriguesParam`.

This adds deprecation warnings for the `RodriguesVec` constructors. I wasn't able to figure out how to deprecate `one(::Type{RodriguesVec})` and `one(::{Type{RodriguesVec{T}})`, so if anybody has a solution to that let me know! Right now it will just throw an error.