### PR TITLE
Avoid unneeded renormalizations of the quaternion

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Rotations"
 uuid = "6038ab10-8711-5258-84ad-4b1120ba62dc"
-version = "0.13.0"
+version = "1.0.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -486,7 +486,7 @@ Jacobian of `R*r` with respect to the rotation
 """
 function ∇rotate(q::UnitQuaternion, r::AbstractVector)
     check_length(r, 3)
-    rhat = UnitQuaternion(zero(eltype(r)), r[1], r[2], r[3])
+    rhat = UnitQuaternion(zero(eltype(r)), r[1], r[2], r[3], false)
     R = rmult(q)
     2vmat()*rmult(q)'rmult(rhat)
 end

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -208,9 +208,9 @@ Base.rand(::Type{UnitQuaternion}) = Base.rand(UnitQuaternion{Float64})
 # ~~~~~~~~~~~~~~~ Math Operations ~~~~~~~~~~~~~~~ #
 
 # Inverses
-conj(q::Q) where Q <: UnitQuaternion = Q(q.w, -q.x, -q.y, -q.z)
+conj(q::Q) where Q <: UnitQuaternion = Q(q.w, -q.x, -q.y, -q.z, false)
 inv(q::UnitQuaternion) = conj(q)
-(-)(q::Q) where Q <: UnitQuaternion = Q(-q.w, -q.x, -q.y, -q.z)
+(-)(q::Q) where Q <: UnitQuaternion = Q(-q.w, -q.x, -q.y, -q.z, false)
 
 # Norms
 LinearAlgebra.norm(q::UnitQuaternion) = sqrt(q.w^2 + q.x^2 + q.y^2 + q.z^2)

--- a/test/unitquat.jl
+++ b/test/unitquat.jl
@@ -22,7 +22,7 @@ import Rotations: vmat, rmult, lmult, hmat, tmat
     @test UnitQuaternion(q) isa UnitQuaternion{Float64}
     @test UnitQuaternion(q32) isa UnitQuaternion{Float32}
 
-    r = normalize(@SVector rand(3))
+    r = @SVector rand(3)
     r32 = SVector{3,Float32}(r)
     @test pure_quaternion(r) isa UnitQuaternion{Float64}
     @test pure_quaternion(r32) isa UnitQuaternion{Float32}


### PR DESCRIPTION
Fixes a few bugs in the unit quaternion code, where the methods renormalize the quaternion when it isn't necessary.