### PR TITLE
Remove unnecessary (broken!) `summary` implementation

### DIFF
--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -235,9 +235,3 @@ function Base.show(io::IO, ::MIME"text/plain", X::Rotation)
     Base.print_array(io, X)
 end
 
-# Removes module name from output, to match other types
-function Base.summary(r::Rotation{N,T}) where {T,N}
-    inds = indices(r)
-    typestring = last(split(string(typeof(r)), '.'; limit = 2))
-    string(Base.dims2string(length.(inds)), " ", typestring)
-end


### PR DESCRIPTION
Fixes #119 - I think we can just delete this because the default `summary` already does a reasonable job:

```julia
julia> Base.summary(RotX(1.0))
"3×3 RotX{Float64} with indices SOneTo(3)×SOneTo(3)"
```