### PR TITLE
Ensure one(::Type{<:RotMatrix{N}}) is implemented

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [targets]
-test = ["BenchmarkTools", "ForwardDiff", "Random", "Test"]
+test = ["BenchmarkTools", "ForwardDiff", "Random", "Test", "InteractiveUtils"]

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -109,6 +109,8 @@ end
     RotMatrix(@SMatrix T[c -s; s c])
 end
 
+Base.one(::Type{R}) where {N,R<:RotMatrix{N}} = R(I)
+
 # A rotation is more-or-less defined as being an orthogonal (or unitary) matrix
 Base.inv(r::RotMatrix) = RotMatrix(r.mat')
 

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -85,6 +85,8 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
 ###############################
 
 @testset "Rotations Tests" begin
+    # Ensure we're testing all 3D rotation types
+    @test length(all_types) == length(setdiff(subtypes(Rotation), [Angle2d]))
 
     ###############################
     # Check fixed relationships
@@ -94,6 +96,7 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
         I = one(SMatrix{3,3,Float64})
         I32 = one(SMatrix{3,3,Float32})
         @testset "$(R)" for R in all_types
+            # one(R) should always return something of type R (#114)
             @test one(R)::R == I
             @test one(R{Float32})::R{Float32} == I32
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using LinearAlgebra
 using Rotations
 using StaticArrays
+using InteractiveUtils: subtypes
 
 import Random
 


### PR DESCRIPTION
`one(::Type{R})` should return something of type `R` for every rotation,
which means implementing this explicitly rather than relying on
StaticArrays which must similar_type which turns into SMatrix.

Fixes #114