### PR TITLE
More correct promotion for `Rot` constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,9 +14,10 @@ julia = "0.7, 1"
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["BenchmarkTools", "ForwardDiff", "Random", "Test", "InteractiveUtils"]
+test = ["BenchmarkTools", "ForwardDiff", "Random", "Test", "InteractiveUtils", "Unitful"]

--- a/src/euler_types.jl
+++ b/src/euler_types.jl
@@ -9,6 +9,10 @@
 # Single axis rotations #
 #########################
 
+# The element type for a rotation matrix with a given angle type is composed of
+# trigonometric functions of that type.
+Base.@pure rot_eltype(angle_type) = typeof(sin(zero(angle_type)))
+
 for axis in [:X, :Y, :Z]
     RotType = Symbol("Rot" * string(axis))
     @eval begin
@@ -18,7 +22,9 @@ for axis in [:X, :Y, :Z]
             $RotType{T}(r::$RotType) where {T} = new{T}(r.theta)
         end
 
-        @inline $RotType(theta::T) where {T} = $RotType{T}(theta)
+        @inline function $RotType(theta)
+            $RotType{rot_eltype(typeof(theta))}(theta)
+        end
         @inline $RotType(r::$RotType{T}) where {T} = $RotType{T}(r)
 
         @inline (::Type{R})(t::NTuple{9}) where {R<:$RotType} = error("Cannot construct a cardinal axis rotation from a matrix")
@@ -222,7 +228,10 @@ for axis1 in [:X, :Y, :Z]
                 $RotType{T}(r::$RotType) where {T} = new{T}(r.theta1, r.theta2)
             end
 
-            @inline $RotType(theta1::T1, theta2::T2) where {T1, T2} = $RotType{promote_type(T1, T2)}(theta1, theta2)
+            @inline function $RotType(theta1, theta2)
+                ts = promote(theta1, theta2)
+                $RotType{rot_eltype(eltype(ts))}(ts...)
+            end
             @inline $RotType(r::$RotType{T}) where {T} = $RotType{T}(r)
 
             @inline function Base.getindex(r::$RotType{T}, i::Int) where T
@@ -502,7 +511,10 @@ for axis1 in [:X, :Y, :Z]
                     $RotType{T}(r::$RotType) where {T} = new{T}(r.theta1, r.theta2, r.theta3)
                 end
 
-                @inline $RotType(theta1::T1, theta2::T2, theta3::T3) where {T1, T2, T3} = $RotType{promote_type(promote_type(T1, T2), T3)}(theta1, theta2, theta3)
+                @inline function $RotType(theta1, theta2, theta3)
+                    ts = promote(theta1, theta2, theta3)
+                    $RotType{rot_eltype(eltype(ts))}(ts...)
+                end
                 @inline $RotType(r::$RotType{T}) where {T} = $RotType{T}(r)
 
                 @inline function Base.getindex(r::$RotType{T}, i::Int) where T

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -305,6 +305,37 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
             end
         end
     end
+#########################################################################
+    # Check that the eltype is inferred in Rot constructors
+    @testset "Rot constructor eltype promotion" begin
+        @test eltype(RotX(10)) == Float64
+        @test eltype(RotX(10.0f0)) == Float32
+        @test eltype(RotX(BigInt(10))) == BigFloat
+
+        @test eltype(RotXY(10, 20)) == Float64
+        @test eltype(RotXY(10.0, 20.0)) == Float64
+        @test eltype(RotXY(10.0f0, 20.0f0)) == Float32
+        # Mixing ints + floats promotes to narrowest float type
+        @test eltype(RotXY(10.0f0, 20)) == Float32
+        @test eltype(RotXY(20.0, BigInt(10))) == BigFloat
+
+        @test eltype(RotXYZ(10, 20, 30)) == Float64
+        @test eltype(RotXYZ(10.0, 20.0, 30.0)) == Float64
+        @test eltype(RotXYZ(10.0f0, 20.0f0, 30.0f0)) == Float32
+        @test eltype(RotXYZ(10.0f0, 20, 30)) == Float32
+
+        # Promotion is correct with dimensionless Unitful types
+        ° = Unitful.°
+        rad = Unitful.rad
+        @test eltype(RotX(10°)) == Float64
+        @test eltype(RotX(10.0f0°)) == Float32
+        @test eltype(RotX(10rad)) == Float64
+        @test eltype(RotX(BigInt(10)*rad)) == BigFloat
+
+        @test RotX(10°) ≈ RotX(deg2rad(10.0))
+        @test RotXY(10°,20°) ≈ RotXY(deg2rad(10.0), deg2rad(20.0))
+        @test RotXYZ(10°,20°,30°) ≈ RotXYZ(deg2rad(10.0), deg2rad(20.0), deg2rad(30.0))
+    end
 
     #########################################################################
     # Check that isrotation works

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using LinearAlgebra
 using Rotations
 using StaticArrays
 using InteractiveUtils: subtypes
+import Unitful
 
 import Random
 


### PR DESCRIPTION
It's common to pass integers to the Rot constructors, but having types
like RotXYZ{Int} are basically useless and confusing because the eltype
as an abstract matrix doesn't match the type of the individual angles.

This is a change to fix the constructors in an attempt to infer a more
correct eltype for the matrix itself.

Notably, this doesn't disentangle the internal representation of the
angles from the logical matrix element type, so this doesn't entirely
fix promotion problems.

Fixes #130, I believe to the extent possible without changing the Rot type signatures.