### PR TITLE
UnitQuaternion scalar division

### DIFF
--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -324,6 +324,10 @@ Scalar divison of a quaternion. Breaks unit norm.
 function (/)(q::Q, w::Real) where Q<:UnitQuaternion
     return Q(q.w/w, q.x/w, q.y/w, q.z/w, false)
 end
+(\)(w::Real, q::UnitQuaternion) = q/w
+(/)(w::Real, q::UnitQuaternion) = w*conj(q)/norm(q)^2      # Equivalent to w*conj(q1) if q1 has unit length
+(\)(q::UnitQuaternion, w::Real) = w/q
+
 
 (\)(q1::UnitQuaternion, q2::UnitQuaternion) = conj(q1)*q2  # Equivalent to inv(q1)*q2
 (/)(q1::UnitQuaternion, q2::UnitQuaternion) = q1*conj(q2)  # Equivalent to q1*inv(q2)

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -316,7 +316,14 @@ function (*)(q::Q, w::Real) where Q<:UnitQuaternion
 end
 (*)(w::Real, q::UnitQuaternion) = q*w
 
+"""
+    (/)(q::UnitQuaternion, w::Real)
 
+Scalar divison of a quaternion. Breaks unit norm.
+"""
+function (/)(q::Q, w::Real) where Q<:UnitQuaternion
+    return Q(q.w/w, q.x/w, q.y/w, q.z/w, false)
+end
 
 (\)(q1::UnitQuaternion, q2::UnitQuaternion) = conj(q1)*q2  # Equivalent to inv(q1)*q2
 (/)(q1::UnitQuaternion, q2::UnitQuaternion) = q1*conj(q2)  # Equivalent to q1*inv(q2)


### PR DESCRIPTION
This adds scalar division for a `UnitQuaternion` `q` and scalar `s`. So far, only scalar multiplication had been implemented.
`q/s` and `s\q` are just element-wise division, `s/q` and `q\s` use the inverse for regular quaternions since multiplication and division with scalars might result in non-unit quaternions.