### PR TITLE
Add Unitful-friendly constructor for Angle2d

### DIFF
--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -163,7 +163,7 @@ end
     end
     x,y = v
     s,c = sincos(r.theta)
-    T = eltype(r)
+    T = Base.promote_op(*, typeof(s), eltype(v))
     similar_type(v,T)(c*x - s*y, s*x + c*y)
 end
 

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -138,6 +138,11 @@ of `getindex` etc. are computed on the fly.
 """
 struct Angle2d{T} <: Rotation{2,T}
     theta::T
+    Angle2d{T}(theta) where T = new{T}(theta)
+end
+
+@inline function Angle2d(theta)
+    Angle2d{rot_eltype(typeof(theta))}(theta)
 end
 
 Angle2d(r::Rotation{2}) = Angle2d(rotation_angle(r))

--- a/src/euler_types.jl
+++ b/src/euler_types.jl
@@ -9,10 +9,6 @@
 # Single axis rotations #
 #########################
 
-# The element type for a rotation matrix with a given angle type is composed of
-# trigonometric functions of that type.
-Base.@pure rot_eltype(angle_type) = typeof(sin(zero(angle_type)))
-
 for axis in [:X, :Y, :Z]
     RotType = Symbol("Rot" * string(axis))
     @eval begin

--- a/src/util.jl
+++ b/src/util.jl
@@ -41,3 +41,9 @@ end
 function vee(S::AbstractMatrix)
     return @SVector [S[3,2], S[1,3], S[2,1]]
 end
+
+"""
+The element type for a rotation matrix with a given angle type is composed of
+trigonometric functions of that type.
+"""
+Base.@pure rot_eltype(angle_type) = typeof(sin(zero(angle_type)))

--- a/test/2d.jl
+++ b/test/2d.jl
@@ -81,6 +81,33 @@ using Unitful
         end
     end
 
+    # a random rotation of a random unitful point
+    @testset "Rotate Unitful Points" begin
+        repeats = 100
+        for R in [RotMatrix{2}, Angle2d]
+            Random.seed!(0)
+            for i = 1:repeats
+                r = rand(R)
+                m = SMatrix(r)
+                v = randn(SVector{2}) * u"m"
+
+                @test r*v ≈ m*v
+                @test eltype(r*v) <: Unitful.Length
+                @test eltype(m*v) <: Unitful.Length
+            end
+
+            # Test Base.Vector also
+            r = rand(R)
+            m = SMatrix(r)
+            v = randn(2) * u"m"
+
+            @test r*v ≈ m*v
+            @test eltype(r*v) <: Unitful.Length
+            @test eltype(m*v) <: Unitful.Length
+        end
+    end
+
+
     # compose two random rotations
     @testset "Compose rotations" begin
         repeats = 100

--- a/test/2d.jl
+++ b/test/2d.jl
@@ -1,4 +1,5 @@
 using Rotations, StaticArrays, Test
+using Unitful: °, rad
 
 @testset "2d Rotations" begin
 
@@ -10,6 +11,13 @@ using Rotations, StaticArrays, Test
         r = one(RotMatrix{2,Float32})
         @test RotMatrix((1,0,0,1)) == RotMatrix(@SMatrix [1 0; 0 1])
         @test_throws DimensionMismatch RotMatrix((1,0,0,1,0))
+    end
+
+    @testset "Unitful" begin
+        # Make sure rotations created from unitful angles
+        # don't extraneously contain those units (see issue #55)
+        @test eltype(Angle2d(10°)) isa Real
+        @test eltype(Angle2d(20rad)) isa Real
     end
 
     ###############################

--- a/test/2d.jl
+++ b/test/2d.jl
@@ -16,8 +16,8 @@ using Unitful: °, rad
     @testset "Unitful" begin
         # Make sure rotations created from unitful angles
         # don't extraneously contain those units (see issue #55)
-        @test eltype(Angle2d(10°)) isa Real
-        @test eltype(Angle2d(20rad)) isa Real
+        @test eltype(Angle2d(10°)) <: Real
+        @test eltype(Angle2d(20rad)) <: Real
     end
 
     ###############################

--- a/test/2d.jl
+++ b/test/2d.jl
@@ -1,5 +1,5 @@
 using Rotations, StaticArrays, Test
-using Unitful: °, rad
+using Unitful
 
 @testset "2d Rotations" begin
 
@@ -16,8 +16,8 @@ using Unitful: °, rad
     @testset "Unitful" begin
         # Make sure rotations created from unitful angles
         # don't extraneously contain those units (see issue #55)
-        @test eltype(Angle2d(10°)) <: Real
-        @test eltype(Angle2d(20rad)) <: Real
+        @test eltype(Angle2d(10u"°")) <: Real
+        @test eltype(Angle2d(20u"rad")) <: Real
     end
 
     ###############################


### PR DESCRIPTION
Hello,

This should fix #55, or at least what I observed in https://github.com/JuliaGeometry/Rotations.jl/issues/55#issuecomment-786473382.

I just noticed that `RotX`, `RotY`, `RotZ` had an additional constructor that `Angle2d` was missing, which also seemed very closely related to @andyferris's  [comment on the issue](https://github.com/JuliaGeometry/Rotations.jl/issues/55#issuecomment-384522571):

https://github.com/JuliaGeometry/Rotations.jl/blob/492b5cdc2b433bd013882f8903db8ff92d30e1c9/src/euler_types.jl#L25-L27

So I mimicked it for `Angle2d` and moved the `rot_eltype` function into the `util` module so that it could be reused in both places. I also wrote a short test to go check that the angular units are consumed.

Edits / feedback welcome.

Cheers!
Oliver