### PR TITLE
Remove numerical unstable RotationVec --> UnitQuaterion conversions

### DIFF
--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -159,11 +159,7 @@ function (::Type{RV})(aa::AngleAxis) where RV <: RotationVec
 end
 
 function (::Type{Q})(rv::RotationVec) where Q <: UnitQuaternion
-    theta = rotation_angle(rv)
-    qtheta = cos(theta / 2)
-    #s = abs(1/2 * sinc((theta / 2) / pi))
-    s = (1/2 * sinc((theta / 2) / pi)) # TODO check this (I removed an abs)
-    return Q(qtheta, s * rv.sx, s * rv.sy, s * rv.sz, false)
+    return UnitQuaternion(AngleAxis(rv))
 end
 
 (::Type{RV})(q::UnitQuaternion) where {RV <: RotationVec} = RV(AngleAxis(q))

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -406,4 +406,11 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
         str = String(take!(io))
         @test startswith(str, "3×3 RotXYZ{Float64}") && occursin("(1.0, 2.0, 3.0):", str)
     end
+
+    #########################################################################
+    # Check that 137 is solved
+    #########################################################################
+    @testset "Regression test issue 137" begin
+        @test det(RotationVec(1e19, 0.0, 0.0)) ≈ 1.
+    end
 end


### PR DESCRIPTION
Instead, rely on internal conversion to AxisAngle rapresentation.

Fix https://github.com/JuliaGeometry/Rotations.jl/issues/137.

Furthermore, at least on my system the microbenchmark on RotationVec --> UnitQuaternion conversion passed from:
~~~
RotationVec{Float64} -> UnitQuaternion{Float64}   28.039 ns
~~~
to 
~~~
RotationVec{Float64} -> UnitQuaternion{Float64}   14.069 ns
~~~