### PR TITLE
Add trivial type conversion for Euler types

### DIFF
--- a/src/euler_types.jl
+++ b/src/euler_types.jl
@@ -241,6 +241,10 @@ for axis1 in [:X, :Y, :Z]
 
             @inline (::Type{R})(t::NTuple{9}) where {R<:$RotType} = error("Cannot construct a two-axis rotation from a matrix")
 
+            # Convert a single-axis rotation to a two-axis rotation:
+            @inline (::Type{R})(r1::$Rot1Type) where {R<:$RotType} = $RotType(r1.theta, 0)
+            @inline (::Type{R})(r2::$Rot2Type) where {R<:$RotType} = $RotType(0, r2.theta)
+
             # Composing single-axis rotations to obtain a two-axis rotation:
             @inline Base.:*(r1::$Rot1Type, r2::$Rot2Type) = $RotType(r1.theta, r2.theta)
 
@@ -521,6 +525,16 @@ for axis1 in [:X, :Y, :Z]
                 @inline function Base.getindex(r::$RotType{T}, i::Int) where T
                     Tuple(r)[i] # Slow...
                 end
+
+                # Convert a single-axis rotation to a three-axis rotation:
+                @inline (::Type{R})(r1::$Rot1Type) where {R<:$RotType} = $RotType(r1.theta, 0, 0)
+                @inline (::Type{R})(r2::$Rot2Type) where {R<:$RotType} = $RotType(0, r2.theta, 0)
+                if $Rot1Type ≠ $Rot3Type
+                    @inline (::Type{R})(r3::$Rot3Type) where {R<:$RotType} = $RotType(0, 0, r3.theta)
+                end
+
+                @inline (::Type{R})(r12::$Rot12Type) where {R<:$RotType} = $RotType(r12.theta1, r12.theta2, 0)
+                @inline (::Type{R})(r23::$Rot23Type) where {R<:$RotType} = $RotType(0, r23.theta1, r23.theta2)
 
                 # Composing single-axis rotations with two-axis rotations:
                 @inline Base.:*(r1::$Rot1Type, r2::$Rot23Type) = $RotType(r1.theta, r2.theta1, r2.theta2)

--- a/src/euler_types.jl
+++ b/src/euler_types.jl
@@ -27,7 +27,8 @@ for axis in [:X, :Y, :Z]
         end
         @inline $RotType(r::$RotType{T}) where {T} = $RotType{T}(r)
 
-        @inline (::Type{R})(t::NTuple{9}) where {R<:$RotType} = error("Cannot construct a cardinal axis rotation from a matrix")
+        @inline $RotType(::NTuple{9}) = error("Cannot construct a cardinal axis rotation from a matrix")
+        @inline $RotType{T}(::NTuple{9}) where T = error("Cannot construct a cardinal axis rotation from a matrix")
 
         @inline Base.:*(r1::$RotType, r2::$RotType) = $RotType(r1.theta + r2.theta)
 

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -399,7 +399,11 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
         r = rand(RotMatrix{2})
         show(io, MIME("text/plain"), r)
         str = String(take!(io))
-        @test startswith(str, "2×2 RotMatrix{2,Float64,4}")
+        if VERSION ≥ v"1.6"
+            @test startswith(str, "2×2 RotMatrix2{Float64}")
+        else
+            @test startswith(str, "2×2 RotMatrix{2,Float64,4}")
+        end
 
         rxyz = RotXYZ(1.0, 2.0, 3.0)
         show(io, MIME("text/plain"), rxyz)


### PR DESCRIPTION
This PR includes the changes in #143 to pass the CI, so please merge the PR first. :pray:

# Before this PR
```julia
julia> RotXY(RotX(10))
ERROR: Cannot construct a two-axis rotation from a matrix
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] RotXY
   @ ~/.julia/dev/Rotations/src/euler_types.jl:241 [inlined]
 [3] RotXY(a::RotX{Float64})
   @ StaticArrays ~/.julia/packages/StaticArrays/rdb0l/src/convert.jl:5
 [4] top-level scope
   @ REPL[3]:1

julia> RotXYZ(RotX(10))
3×3 RotXYZ{Float64} with indices SOneTo(3)×SOneTo(3)(-2.56637, 0.0, -0.0):
 1.0   0.0        0.0
 0.0  -0.839072   0.544021
 0.0  -0.544021  -0.839072

julia> @benchmark RotXYZ(RotX(10))
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     39.974 ns (0.00% GC)
  median time:      40.712 ns (0.00% GC)
  mean time:        41.134 ns (0.00% GC)
  maximum time:     60.912 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     991
```

# After this PR
```julia
julia> RotXY(RotX(10))
3×3 RotXY{Float64} with indices SOneTo(3)×SOneTo(3)(10.0, 0.0):
  1.0   0.0        0.0
 -0.0  -0.839072   0.544021
  0.0  -0.544021  -0.839072

julia> RotXYZ(RotX(10))
3×3 RotXYZ{Float64} with indices SOneTo(3)×SOneTo(3)(10.0, 0.0, 0.0):
  1.0  -0.0        0.0
 -0.0  -0.839072   0.544021
  0.0  -0.544021  -0.839072

julia> @benchmark RotXYZ(RotX(10))
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     0.020 ns (0.00% GC)
  median time:      0.020 ns (0.00% GC)
  mean time:        0.023 ns (0.00% GC)
  maximum time:     8.646 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000
```

# Note
In some cases, the type conversion can be non-trivial. For example, `RotX(t)` can be conveted to two ways `RotXYX(t,0,0)` and `RotXYX(0,0,t)`. With this PR, the first `RotXYX(t,0,0)` will be choosen.

```julia
julia> RotXYX(RotX(10))
3×3 RotXYX{Float64} with indices SOneTo(3)×SOneTo(3)(10.0, 0.0, 0.0):
  1.0   0.0        0.0
 -0.0  -0.839072   0.544021
  0.0  -0.544021  -0.839072

julia> RotZYZ(RotZ(42))
3×3 RotZYZ{Float64} with indices SOneTo(3)×SOneTo(3)(42.0, 0.0, 0.0):
 -0.399985   0.916522  -0.0
 -0.916522  -0.399985  -0.0
 -0.0        0.0        1.0
```