### PR TITLE
Fix norm2 for Base.:/(R1::MRP,R2::MRP)

### DIFF
--- a/src/euler_types.jl
+++ b/src/euler_types.jl
@@ -27,7 +27,8 @@ for axis in [:X, :Y, :Z]
         end
         @inline $RotType(r::$RotType{T}) where {T} = $RotType{T}(r)
 
-        @inline (::Type{R})(t::NTuple{9}) where {R<:$RotType} = error("Cannot construct a cardinal axis rotation from a matrix")
+        @inline $RotType(::NTuple{9}) = error("Cannot construct a cardinal axis rotation from a matrix")
+        @inline $RotType{T}(::NTuple{9}) where T = error("Cannot construct a cardinal axis rotation from a matrix")
 
         @inline Base.:*(r1::$RotType, r2::$RotType) = $RotType(r1.theta + r2.theta)
 

--- a/src/mrps.jl
+++ b/src/mrps.jl
@@ -70,7 +70,7 @@ function (\)(p1::MRP, p2::MRP)
 end
 
 function (/)(p1::MRP, p2::MRP)
-    n1,n2 = norm2(p1),   norm2(p2)
+    n1,n2 = LinearAlgebra.norm2(p1),   LinearAlgebra.norm2(p2)
     θ = 1/((1+n1)*(1+n2))
     s1,s2 = (1-n1), (1-n2)
     p1,p2 = params(p1), params(p2)
@@ -195,7 +195,7 @@ end
 Jacobian of `p1\\p2` wrt `p2`
 """
 function ∇err(p1::MRP, p2::MRP)
-    n1,n2 = norm2(p1),   norm2(p2)
+    n1,n2 = LinearAlgebra.norm2(p1),   LinearAlgebra.norm2(p2)
     θ = 1/((1+n1)*(1+n2))
     s1,s2 = (1-n1), (1-n2)
     p1,p2 = params(p1), params(p2)
@@ -219,7 +219,7 @@ Jacobian of `(∂/∂p p1\\p2)'b` wrt `p2`
 """
 function ∇²err(p1::MRP, p2::MRP, b::AbstractVector)
     check_length(b, 3)
-    n1,n2 = norm2(p1),   norm2(p2)
+    n1,n2 = LinearAlgebra.norm2(p1),   LinearAlgebra.norm2(p2)
     θ = 1/((1+n1)*(1+n2))
     s1,s2 = (1-n1), (1-n2)
     p1,p2 = params(p1), params(p2)

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -117,6 +117,8 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
                 @test inv(r) == transpose(r)
                 @test inv(r)*r ≈ I
                 @test r*inv(r) ≈ I
+                @test r/r ≈ I
+                @test r\r ≈ I
             end
         end
     end

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -399,7 +399,11 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
         r = rand(RotMatrix{2})
         show(io, MIME("text/plain"), r)
         str = String(take!(io))
-        @test startswith(str, "2×2 RotMatrix{2,Float64,4}")
+        if VERSION ≥ v"1.6"
+            @test startswith(str, "2×2 RotMatrix2{Float64}")
+        else
+            @test startswith(str, "2×2 RotMatrix{2,Float64,4}")
+        end
 
         rxyz = RotXYZ(1.0, 2.0, 3.0)
         show(io, MIME("text/plain"), rxyz)


### PR DESCRIPTION
This PR fixes #149.
I've added tests for `Base.:/` and `Base.:\`, and fixed the `UndefVarError` of `norm2`.

(This PR includes the changes in #143 to pass the CI, so please merge the PR first. :pray:)