### PR TITLE
Fix rand methods for rotations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "1.0.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 

--- a/src/Rotations.jl
+++ b/src/Rotations.jl
@@ -5,6 +5,7 @@ module Rotations
 
 using LinearAlgebra
 using StaticArrays
+using Random
 
 import Statistics
 

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -25,25 +25,25 @@ Base.convert(::Type{R}, rot::Rotation{N}) where {N,R<:Rotation{N}} = R(rot)
 Base.@pure StaticArrays.similar_type(::Union{R,Type{R}}) where {R <: Rotation} = SMatrix{size(R)..., eltype(R), prod(size(R))}
 Base.@pure StaticArrays.similar_type(::Union{R,Type{R}}, ::Type{T}) where {R <: Rotation, T} = SMatrix{size(R)..., T, prod(size(R))}
 
-function Base.rand(::Type{R}) where R <: Rotation{2}
+function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Rotation{2}
     T = eltype(R)
     if T == Any
         T = Float64
     end
 
-    R(2π * rand(T))
+    R(2π * rand(rng, T))
 end
 
 # A random rotation can be obtained easily with unit quaternions
 # The unit sphere in R⁴ parameterizes quaternion rotations according to the
 # Haar measure of SO(3) - see e.g. http://math.stackexchange.com/questions/184086/uniform-distributions-on-the-space-of-rotations-in-3d
-function Base.rand(::Type{R}) where R <: Rotation{3}
+function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Rotation{3}
     T = eltype(R)
     if T == Any
         T = Float64
     end
 
-    q = UnitQuaternion(randn(T), randn(T), randn(T), randn(T))
+    q = UnitQuaternion(randn(rng, T), randn(rng, T), randn(rng, T), randn(rng, T))
     return R(q)
 end
 

--- a/src/euler_types.jl
+++ b/src/euler_types.jl
@@ -40,13 +40,13 @@ for axis in [:X, :Y, :Z]
     end
 end
 
-function Base.rand(::Type{R}) where R <: Union{RotX,RotY,RotZ}
+function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Union{RotX,RotY,RotZ}
     T = eltype(R)
     if T == Any
         T = Float64
     end
 
-    return R(2*pi*rand(T))
+    return R(2π*rand(rng, T))
 end
 
 
@@ -257,7 +257,7 @@ for axis1 in [:X, :Y, :Z]
     end
 end
 
-function Base.rand(::Type{R}) where R <: Union{RotXY,RotYZ,RotZX, RotXZ, RotYX, RotZY}
+function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Union{RotXY,RotYZ,RotZX, RotXZ, RotYX, RotZY}
     T = eltype(R)
     if T == Any
         T = Float64
@@ -266,7 +266,7 @@ function Base.rand(::Type{R}) where R <: Union{RotXY,RotYZ,RotZX, RotXZ, RotYX, 
     # Not really sure what this distribution is, but it's also not clear what
     # it should be! rand(RotXY) *is* invariant to pre-rotations by a RotX and
     # post-rotations by a RotY...
-    return R(2*pi*rand(T), 2*pi*rand(T))
+    return R(2π*rand(rng, T), 2π*rand(rng, T))
 end
 
 

--- a/src/euler_types.jl
+++ b/src/euler_types.jl
@@ -27,7 +27,8 @@ for axis in [:X, :Y, :Z]
         end
         @inline $RotType(r::$RotType{T}) where {T} = $RotType{T}(r)
 
-        @inline (::Type{R})(t::NTuple{9}) where {R<:$RotType} = error("Cannot construct a cardinal axis rotation from a matrix")
+        @inline $RotType(::NTuple{9}) = error("Cannot construct a cardinal axis rotation from a matrix")
+        @inline $RotType{T}(::NTuple{9}) where T = error("Cannot construct a cardinal axis rotation from a matrix")
 
         @inline Base.:*(r1::$RotType, r2::$RotType) = $RotType(r1.theta + r2.theta)
 

--- a/src/mrps.jl
+++ b/src/mrps.jl
@@ -25,7 +25,9 @@ MRP(x::X, y::Y, z::Z) where {X,Y,Z} = MRP{promote_type(X,Y,Z)}(x, y, z)
 params(g::MRP) = SVector{3}(g.x, g.y, g.z)
 
 # ~~~~~~~~~~~~~~~ Initializers ~~~~~~~~~~~~~~~ #
-Base.rand(::Type{RP}) where RP <: MRP = RP(rand(UnitQuaternion))
+function Random.rand(rng::AbstractRNG, ::Random.SamplerType{RP}) where RP <: MRP
+    RP(rand(rng, UnitQuaternion))
+end
 Base.one(::Type{RP}) where RP <: MRP = RP(0.0, 0.0, 0.0)
 
 # ~~~~~~~~~~~~~~~~ Quaternion <=> MRP ~~~~~~~~~~~~~~~~~~ #

--- a/src/rodrigues_params.jl
+++ b/src/rodrigues_params.jl
@@ -23,7 +23,9 @@ RodriguesParam(x::X, y::Y, z::Z) where {X,Y,Z} = RodriguesParam{promote_type(X,Y
 params(g::RodriguesParam) = SVector{3}(g.x, g.y, g.z)
 
 # ~~~~~~~~~~~~~~~ Initializers ~~~~~~~~~~~~~~~ #
-@inline Base.rand(::Type{RP}) where RP <: RodriguesParam = RP(rand(UnitQuaternion))
+@inline function Random.rand(rng::AbstractRNG, ::Random.SamplerType{RP}) where RP <: RodriguesParam
+    RP(rand(rng, UnitQuaternion))
+end
 @inline Base.one(::Type{RP}) where RP <: RodriguesParam = RP(0.0, 0.0, 0.0)
 
 # ~~~~~~~~~~~~~~~ Quaternion <=> RP ~~~~~~~~~~~~~~~~~~ #

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -198,9 +198,9 @@ Rotations.params(p) == @SVector [1.0, 2.0, 3.0]  # true
 @inline params(q::UnitQuaternion) = SVector{4}(q.w, q.x, q.y, q.z)
 
 # ~~~~~~~~~~~~~~~ Initializers ~~~~~~~~~~~~~~~ #
-Base.rand(::Type{<:UnitQuaternion{T}}) where T =
-    normalize(UnitQuaternion{T}(randn(T), randn(T), randn(T), randn(T)))
-Base.rand(::Type{UnitQuaternion}) = Base.rand(UnitQuaternion{Float64})
+function Random.rand(rng::AbstractRNG, ::Random.SamplerType{<:UnitQuaternion{T}}) where T
+    normalize(UnitQuaternion{T}(randn(rng,T), randn(rng,T), randn(rng,T), randn(rng,T)))
+end
 @inline Base.zero(::Type{Q}) where Q <: UnitQuaternion = Q(1.0, 0.0, 0.0, 0.0)
 @inline Base.one(::Type{Q}) where Q <: UnitQuaternion = Q(1.0, 0.0, 0.0, 0.0)
 

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -399,7 +399,11 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
         r = rand(RotMatrix{2})
         show(io, MIME("text/plain"), r)
         str = String(take!(io))
-        @test startswith(str, "2×2 RotMatrix{2,Float64,4}")
+        if VERSION ≥ v"1.6"
+            @test startswith(str, "2×2 RotMatrix2{Float64}")
+        else
+            @test startswith(str, "2×2 RotMatrix{2,Float64,4}")
+        end
 
         rxyz = RotXYZ(1.0, 2.0, 3.0)
         show(io, MIME("text/plain"), rxyz)


### PR DESCRIPTION
This PR fixes #148.

# Before this PR
```julia
julia> rand(RotMatrix{3}, 3)
3-element Vector{RotMatrix{3, T, L} where {T, L}}:
 [0.9262304734005136 0.07704595973104111 0.05312094584317828; 0.5758617641085089 0.33783342046229015 0.9893885121870893; 0.005333550147850197 0.8302770921468592 0.11567706349399498]
 [0.7288275903902528 0.4715567450274505 0.017856704946666246; 0.4146825205496094 0.8633298086113015 0.3939495842452325; 0.10046930970693801 0.5212854180419362 0.43489244736632715]
 [0.29230907187737154 0.05374113409394754 0.3757707367946417; 0.5261950324226174 0.6202434242930548 0.13718264294349303; 0.4242728376908569 0.06203073672460513 0.3502348244334794]

julia> isrotation(rand(RotMatrix3{Float64},3)[1])
false
```

# After this PR
```julia
julia> rand(RotMatrix{3}, 3)
3-element Vector{RotMatrix{3, T, L} where {T, L}}:
 [-0.933159216082458 0.303135315628194 0.19319124684976668; -0.35945223508433005 -0.7911290696569423 -0.49488269906778953; 0.002822788205273638 -0.5312473769937467 0.8472120491966648]
 [-0.6024442839420462 0.7259886958946182 0.3316644361079223; -0.7559462145926497 -0.3856380639469435 -0.5289882836871683; -0.2561370831968659 -0.5694064427704378 0.7811338537939047]
 [-0.7688707262451 -0.5227835457711413 -0.36815101601691386; -0.6192210418785496 0.7523153066735825 0.2249154966636972; 0.15938352367223058 0.40089779697023414 -0.9021517880967908]

julia> isrotation(rand(RotMatrix3{Float64},3)[1])
true
```

(This PR includes the changes in #143 to pass the CI, so please merge the PR first. :pray:)