### PR TITLE
Add `log(::Rotation)`

### DIFF
--- a/src/Rotations.jl
+++ b/src/Rotations.jl
@@ -22,6 +22,7 @@ include("principal_value.jl")
 include("rodrigues_params.jl")
 include("error_maps.jl")
 include("rotation_error.jl")
+include("log.jl")
 include("eigen.jl")
 include("deprecated.jl")
 

--- a/src/log.jl
+++ b/src/log.jl
@@ -13,7 +13,7 @@ end
 
 # 2d
 function Base.log(R::Angle2d)
-    θ = params(R)
+    θ, = params(R)
     return @SMatrix [0 -θ
                      θ  0]
 end

--- a/src/log.jl
+++ b/src/log.jl
@@ -1,0 +1,23 @@
+# 3d
+function Base.log(R::RotationVec)
+    x, y, z = params(R)
+    return @SMatrix [0 -z  y
+                     z  0 -x
+                    -y  x  0]
+end
+
+function Base.log(R::Rotation{3})
+    log(RotationVec(R))
+end
+
+
+# 2d
+function Base.log(R::Angle2d)
+    θ = params(R)
+    return @SMatrix [0 -θ
+                     θ  0]
+end
+
+function Base.log(R::Rotation{2})
+    log(Angle2d(R))
+end

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -254,7 +254,7 @@ function expm(ϕ::AbstractVector)
     UnitQuaternion(cθ, ϕ[1]*M, ϕ[2]*M, ϕ[3]*M, false)
 end
 
-function log(q::Q, eps=1e-6) where Q <: UnitQuaternion
+function _log_as_quat(q::Q, eps=1e-6) where Q <: UnitQuaternion
     # Assumes unit quaternion
     θ = vecnorm(q)
     if θ > eps
@@ -267,7 +267,7 @@ end
 
 function logm(q::UnitQuaternion)
     # Assumes unit quaternion
-    2*vector(log(q))
+    2*vector(_log_as_quat(q))
 end
 
 # Composition

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -1,4 +1,4 @@
-import Base: +, -, *, /, \, exp, log, ≈, ==, inv, conj
+import Base: +, -, *, /, \, exp, ≈, ==, inv, conj
 
 """
     UnitQuaternion{T} <: Rotation

--- a/test/log.jl
+++ b/test/log.jl
@@ -1,0 +1,23 @@
+@testset "log_3D" begin
+    all_types = (RotMatrix{3}, AngleAxis, RotationVec,
+                 UnitQuaternion, RodriguesParam, MRP,
+                 RotXYZ, RotYZX, RotZXY, RotXZY, RotYXZ, RotZYX,
+                 RotXYX, RotYZY, RotZXZ, RotXZX, RotYXY, RotZYZ,
+                 RotX, RotY, RotZ,
+                 RotXY, RotYZ, RotZX, RotXZ, RotYX, RotZY)
+    oneaxis_types = (RotX, RotY, RotZ)
+
+    @testset "$(T)" for T in all_types, F in (one, rand)
+        R = F(T)
+        @test R ≈ exp(log(R))
+    end
+end
+
+@testset "log_2D" begin
+    all_types = (RotMatrix{2}, Angle2d)
+
+    @testset "$(T)" for T in all_types, θ in 0.0:0.1:π
+        R = F(T)
+        @test R ≈ exp(log(R))
+    end
+end

--- a/test/log.jl
+++ b/test/log.jl
@@ -1,23 +1,15 @@
-@testset "log_3D" begin
+@testset "log" begin
     all_types = (RotMatrix{3}, AngleAxis, RotationVec,
                  UnitQuaternion, RodriguesParam, MRP,
                  RotXYZ, RotYZX, RotZXY, RotXZY, RotYXZ, RotZYX,
                  RotXYX, RotYZY, RotZXZ, RotXZX, RotYXY, RotZYZ,
                  RotX, RotY, RotZ,
-                 RotXY, RotYZ, RotZX, RotXZ, RotYX, RotZY)
-    oneaxis_types = (RotX, RotY, RotZ)
+                 RotXY, RotYZ, RotZX, RotXZ, RotYX, RotZY,
+                 RotMatrix{2}, Angle2d)
 
     @testset "$(T)" for T in all_types, F in (one, rand)
         R = F(T)
         @test R ≈ exp(log(R))
-    end
-end
-
-@testset "log_2D" begin
-    all_types = (RotMatrix{2}, Angle2d)
-
-    @testset "$(T)" for T in all_types, θ in 0.0:0.1:π
-        R = F(T)
-        @test R ≈ exp(log(R))
+        @test log(R) isa SMatrix
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ include("quatmaps.jl")
 include("rotation_error.jl")
 include("distribution_tests.jl")
 include("eigen.jl")
+include("log.jl")
 include("deprecated.jl")
 
 include(joinpath(@__DIR__, "..", "perf", "runbenchmarks.jl"))

--- a/test/unitquat.jl
+++ b/test/unitquat.jl
@@ -125,7 +125,8 @@ import Rotations: vmat, rmult, lmult, hmat, tmat
     @test expm(SA_F32[1, 2, 3]) isa UnitQuaternion{Float32}
 
     q32 = rand(UnitQuaternion{Float32})
-    @test log(q32) isa UnitQuaternion{Float32}
+    @test Rotations._log_as_quat(q32) isa UnitQuaternion{Float32}
+#     @test log(q32) isa Rotation
     @test eltype(logm(q32)) == Float32
     @test expm(logm(q32)) ≈ q32
 

--- a/test/unitquat.jl
+++ b/test/unitquat.jl
@@ -126,7 +126,7 @@ import Rotations: vmat, rmult, lmult, hmat, tmat
 
     q32 = rand(UnitQuaternion{Float32})
     @test Rotations._log_as_quat(q32) isa UnitQuaternion{Float32}
-#     @test log(q32) isa Rotation
+    @test log(q32) isa SMatrix
     @test eltype(logm(q32)) == Float32
     @test expm(logm(q32)) ≈ q32
 


### PR DESCRIPTION
I've added methods for `log(::Rotation)` with return type `SMatrix`. (related comment in other PR: https://github.com/JuliaGeometry/Rotations.jl/pull/170#issuecomment-950970607)

Note that the return value type of `log(::UnitQuaternion)` has been changed. (`UnitQuaternion` -> `SMatrix`, which was a bug before)