### PR TITLE
Remove `mean` method for rotations

### DIFF
--- a/src/Rotations.jl
+++ b/src/Rotations.jl
@@ -15,7 +15,8 @@ include("unitquaternion.jl")
 include("mrps.jl")
 include("euler_types.jl")
 include("angleaxis_types.jl")
-include("mean.jl")
+# TODO: Add method `mean_rotation` instead of `mean`
+# include("mean.jl")
 include("derivatives.jl")
 include("principal_value.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,8 +16,6 @@ ramb = detect_ambiguities(Rotations, Base, Core)
 samb = detect_ambiguities(StaticArrays, Base, Core)
 @test isempty(setdiff(ramb, samb))
 
-# TODO test mean()
-
 include("util_tests.jl")
 include("2d.jl")
 include("rotation_tests.jl")


### PR DESCRIPTION
This PR fixes #91.

The `Statistics.mean(::AbstractArray{<:Rotations})` method should return `SMatrix`. (cf. https://github.com/JuliaGeometry/Rotations.jl/issues/91#issuecomment-460044732)
I've just removed the current definition of the method `mean(::AbstractArray{<:Rotations})`.

## Before this PR
```julia
julia> using Rotations, Statistics

julia> mean([RotX(i) for i in 1:3])
ERROR: UndefVarError: mean not defined
Stacktrace:
 [1] mean(vec::Vector{RotX{Float64}})
   @ Rotations ~/.julia/dev/Rotations/src/mean.jl:50
 [2] top-level scope
   @ REPL[2]:1
```

## After this PR
```julia
julia> using Rotations, Statistics

julia> mean([RotX(i) for i in 1:3])
3×3 StaticArrays.SMatrix{3, 3, Float64, 9} with indices SOneTo(3)×SOneTo(3):
 1.0   0.0        0.0
 0.0  -0.288612  -0.630629
 0.0   0.630629  -0.288612
```

## Note
I think the original method is useful if works fine, but the method should be renamed such as `mean_rotation` instead of `Statistics.mean`.
This should be fixed in other PR, and I haven't removed the original file `src/mean.jl`.
