### PR TITLE
Fix `principal_value` method

### DIFF
--- a/src/principal_value.jl
+++ b/src/principal_value.jl
@@ -16,7 +16,7 @@ the following properties:
 - the `RotationVec` rotation is at most `pi`
 
 """
-principal_value(r::RotMatrix) = r
+principal_value(r::Rotation) = r
 principal_value(q::Q) where Q <: UnitQuaternion = q.w < zero(eltype(q)) ? Q(-q.w, -q.x, -q.y, -q.z, false) : q
 function principal_value(spq::MRP{T}) where {T}
     # A quat with positive real part: UnitQuaternion( qw,  qx,  qy,  qz)
@@ -61,7 +61,7 @@ function principal_value(rv::RotationVec{T}) where {T}
     end
 end
 
-for rot_type in [:RotX, :RotY, :RotZ]
+for rot_type in [:RotX, :RotY, :RotZ, :Angle2d]
     @eval begin
         function principal_value(r::$rot_type{T}) where {T}
             return $(rot_type){T}(rem2pi(r.theta, RoundNearest))

--- a/src/principal_value.jl
+++ b/src/principal_value.jl
@@ -6,7 +6,7 @@ particular set of numbers is better conditioned (e.g. `MRP`) or obeys a particul
 non-negative rotation). In order to preserve differentiability it is necessary to allow rotation representations to
 travel slightly away from the nominal domain; this is critical for applications such as optimization or dynamics.
 
-This function takes a rotation type (e.g. `UnitQuaternion, `RotXY`) and outputs a new rotation of the same type that corresponds
+This function takes a rotation type (e.g. `UnitQuaternion`, `RotXY`) and outputs a new rotation of the same type that corresponds
 to the same `RotMatrix`, but that obeys certain conventions or is better conditioned. The outputs of the function have
 the following properties:
 

--- a/test/principal_value_tests.jl
+++ b/test/principal_value_tests.jl
@@ -39,7 +39,20 @@ end
     @test rv_prin ≈ rv
 end
 
-@testset "Principal Value ($(rot_type))" for rot_type in [:RotX, :RotY, :RotZ] begin
+@testset "Principal Value (Rodrigues Parameters)" begin
+    for i = 1:1000
+        rv = RodriguesParam(100.0 * randn(), 100.0 * randn(), 100.0 * randn())
+        rv_prin = principal_value(rv)
+        @test rv_prin ≈ rv
+        @test Rotations.params(rv_prin) ≈ Rotations.params(rv)
+    end
+    rv = RodriguesParam(0.0, 0.0, 0.0)
+    rv_prin = principal_value(rv)
+    @test rv_prin ≈ rv
+    @test Rotations.params(rv_prin) ≈ Rotations.params(rv)
+end
+
+@testset "Principal Value ($(rot_type))" for rot_type in [:RotX, :RotY, :RotZ, :Angle2d] begin
         @eval begin
             for i = 1:1000
                 r = $(rot_type)(100.0 * randn())


### PR DESCRIPTION
This PR fixes #179.

```julia
julia> principal_value(RodriguesParam(1,2,3))
3×3 RodriguesParam{Int64} with indices SOneTo(3)×SOneTo(3)(1, 2, 3):
 -0.733333  -0.133333  0.666667
  0.666667  -0.333333  0.666667
  0.133333   0.933333  0.333333

julia> principal_value(Angle2d(5.0))
2×2 Angle2d{Float64} with indices SOneTo(2)×SOneTo(2)(-1.28319):
  0.283662  0.958924
 -0.958924  0.283662
```