### PR TITLE
Add `nearest_rotation` function

### DIFF
--- a/docs/src/functions.md
+++ b/docs/src/functions.md
@@ -47,6 +47,24 @@ Check the given matrix is rotation matrix.
 
 (TBW)
 
+## `nearest_rotation`
+
+```@setup nearest_rotation
+using Rotations
+```
+
+Get the nearest special orthonormal matrix from given matrix `M`.
+The problem of finding the orthogonal matrix nearest to a given matrix is related to the [Wahba's problem](https://en.wikipedia.org/wiki/Wahba%27s_problem).
+
+**example**
+
+```@repl nearest_rotation
+M = randn(3,3)  # Generate random matrix
+R = nearest_rotation(M)  # Find the nearest rotation matrix
+U, V = R\M, M/R  # Polar decomposition of M
+U ≈ U'  # U is a symmetric matrix (The same for V)
+```
+
 ## `rand`
 ```@setup rand
 using Rotations

--- a/src/Rotations.jl
+++ b/src/Rotations.jl
@@ -28,6 +28,7 @@ include("eigen.jl")
 include("deprecated.jl")
 
 export
+    # Rotation types
     Rotation, RotMatrix, RotMatrix2, RotMatrix3,
     Angle2d,
     Quat, UnitQuaternion,
@@ -45,6 +46,9 @@ export
 
     # check validity of the rotation (is it close to unitary?)
     isrotation,
+
+    # Get nearest rotation matrix
+    nearest_rotation,
 
     # angle and axis introspection
     rotation_angle,

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -228,6 +228,27 @@ function isrotation(r::AbstractMatrix{T}, tol::Real = 1000 * _isrotation_eps(elt
     return d <= tol && det(r) > 0
 end
 
+"""
+    nearest_rotation(M) -> RotMatrix
+
+Get the nearest special orthonormal matrix from given matrix `M`.
+See [Wahba's problem](https://en.wikipedia.org/wiki/Wahba%27s_problem) for more information.
+"""
+function nearest_rotation(M::StaticMatrix{N,N}) where N
+    u, _, v = svd(M)
+    s = sign(det(u * v'))
+    d = @SVector ones(N-1)
+    R = u * Diagonal(push(d,s)) * v'
+    return RotMatrix{N}(R)
+end
+
+function nearest_rotation(M::AbstractMatrix{T}) where T
+    N = size(M,1)
+    L = N^2
+    M_ = convert(SMatrix{N,N,T,L}, M)
+    return nearest_rotation(M_)
+end
+
 # A simplification and specialization of the Base.show function for AbstractArray makes
 # everything sensible at the REPL.
 function Base.show(io::IO, ::MIME"text/plain", X::Rotation)

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -64,13 +64,8 @@ function (::Type{Q})(t::NTuple{9}) where Q<:UnitQuaternion
     This function solves the system of equations in Section 3.1
     of https://arxiv.org/pdf/math/0701759.pdf. This cheap method
     only works for matrices that are already orthonormal (orthogonal
-    and unit length columns). The nearest orthonormal matrix can
-    be found by solving Wahba's problem:
-    https://en.wikipedia.org/wiki/Wahba%27s_problem as shown below.
-
-    not_orthogonal = randn(3,3)
-    u,s,v = svd(not_orthogonal)
-    is_orthogoral = u * diagm([1, 1, sign(det(u * transpose(v)))]) * transpose(v)
+    and unit length columns).
+    Use `nearest_rotation` to get rotation matrix from the given matrix.
     =#
 
     a = 1 + t[1] + t[5] + t[9]

--- a/test/nearest_rotation.jl
+++ b/test/nearest_rotation.jl
@@ -9,6 +9,7 @@
             # R is rotation matrix
             @test isrotation(R)
             # U, V are (approximately) symmetric matrices
+            # See [polar decomposition](https://en.wikipedia.org/wiki/Polar_decomposition)
             @test U ≈ U'
             @test V ≈ V'
             # Eigen values are non-negative, except for the first value.

--- a/test/nearest_rotation.jl
+++ b/test/nearest_rotation.jl
@@ -1,0 +1,33 @@
+@testset "nearest_rotation" begin
+    @testset "$(N)-dim" for N in [2,3]
+        for _ in 1:100
+            M = randn(N,N)
+            R = nearest_rotation(M)
+            V = M/R
+            U = R\M
+
+            # R is rotation matrix
+            @test isrotation(R)
+            # U, V are (approximately) symmetric matrices
+            @test U ≈ U'
+            @test V ≈ V'
+            # Eigen values are non-negative, except for the first value.
+            @test all(eigvals(U)[2:end] .≥ 0)
+            @test all(eigvals(V)[2:end] .≥ 0)
+        end
+
+        for _ in 1:100
+            M = @SMatrix randn(N,N)
+            R = nearest_rotation(M)
+            V = M/R
+            U = R\M
+
+            @test isrotation(R)
+            @test U ≈ U'
+            @test V ≈ V'
+            # Can't calculate eigen values of general SMatrix.
+            @test all(eigvals(Symmetric(U))[2:end] .≥ 0)
+            @test all(eigvals(Symmetric(V))[2:end] .≥ 0)
+        end
+    end
+end

--- a/test/nearest_rotation.jl
+++ b/test/nearest_rotation.jl
@@ -13,8 +13,9 @@
             @test U ≈ U'
             @test V ≈ V'
             # Eigen values are non-negative, except for the first value.
-            @test all(eigvals(U)[2:end] .≥ 0)
-            @test all(eigvals(V)[2:end] .≥ 0)
+            # We just need sort for Julia 1.0
+            @test all(sort(eigvals(U))[2:end] .≥ 0)
+            @test all(sort(eigvals(V))[2:end] .≥ 0)
         end
 
         for _ in 1:100
@@ -27,8 +28,8 @@
             @test U ≈ U'
             @test V ≈ V'
             # Can't calculate eigen values of general SMatrix.
-            @test all(eigvals(Symmetric(U))[2:end] .≥ 0)
-            @test all(eigvals(Symmetric(V))[2:end] .≥ 0)
+            @test all(sort(eigvals(Symmetric(U)))[2:end] .≥ 0)
+            @test all(sort(eigvals(Symmetric(V)))[2:end] .≥ 0)
         end
     end
 end

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -252,11 +252,6 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
     #########################################################################
     # Test robustness of DCM to UnitQuaternion function
     #########################################################################
-    function nearest_orthonormal(not_orthonormal)
-        u,s,v = svd(not_orthonormal)
-        return u * Diagonal([1, 1, sign(det(u * transpose(v)))]) * transpose(v)
-    end
-
     @testset "DCM to UnitQuaternion" begin
         pert = 1e-3
         for type_rot in all_types
@@ -264,7 +259,7 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
                 not_orthonormal = rand(type_rot) + rand(3, 3) * pert
                 quat_ill_cond = UnitQuaternion(not_orthonormal)
                 @test 0 <= quat_ill_cond.w
-                @test norm(quat_ill_cond - nearest_orthonormal(not_orthonormal)) < 10 * pert
+                @test norm(quat_ill_cond - nearest_rotation(not_orthonormal)) < 10 * pert
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,7 @@ include("rotation_error.jl")
 include("distribution_tests.jl")
 include("eigen.jl")
 include("log.jl")
+include("nearest_rotation.jl")
 include("deprecated.jl")
 
 include(joinpath(@__DIR__, "..", "perf", "runbenchmarks.jl"))


### PR DESCRIPTION
We already have `nearest_orthononormal` function in the [`test/rotation_tests.jl`](https://github.com/JuliaGeometry/Rotations.jl/blob/v1.0.4/test/rotation_tests.jl#L255). I think it's better to have this function in `src` and should be exported.