### PR TITLE
Fix `Base.one(::Angle2d)` method and etc.

### DIFF
--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -23,6 +23,9 @@ Base.zeros(::Type{R}, dims::Base.DimOrInd...) where {R<:Rotation} = zeros(typeof
 Base.zeros(::Type{R}, dims::NTuple{N, Integer}) where {R<:Rotation, N} = zeros(typeof(zero(R)),dims)
 Base.zeros(::Type{R}, dims::Tuple{}) where {R<:Rotation} = zeros(typeof(zero(R)),dims) # avoid ambiguity
 
+# Generate identity rotation matrix
+Base.one(r::Rotation) = one(typeof(r))
+
 # Rotation angles and axes can be obtained by converting to the AngleAxis type
 rotation_angle(r::Rotation{3}) = rotation_angle(AngleAxis(r))
 rotation_axis(r::Rotation{3}) = rotation_axis(AngleAxis(r))

--- a/test/2d.jl
+++ b/test/2d.jl
@@ -31,7 +31,9 @@ using Unitful
             @test @inferred(size(R)) == (2,2)
             @test @inferred(size(R{Float32})) == (2,2)
             @test one(R)::R == I
+            @test one(one(R))::R == I
             @test one(R{Float32})::R{Float32} == I32
+            @test one(one(R{Float32}))::R{Float32} == I32
         end
     end
 

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -98,7 +98,9 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
         @testset "$(R)" for R in all_types
             # one(R) should always return something of type R (#114)
             @test one(R)::R == I
+            @test one(one(R))::R == I
             @test one(R{Float32})::R{Float32} == I32
+            @test one(one(R{Float32}))::R{Float32} == I32
         end
     end
 


### PR DESCRIPTION
This PR fixes #194.

**Before this PR**
```julia
julia> one(Angle2d(0.1))
ERROR: MethodError: Cannot `convert` an object of type NTuple{4, Float64} to an object of type Float64
Closest candidates are:
  convert(::Type{T}, ::Base.TwicePrecision) where T<:Number at twiceprecision.jl:250
  convert(::Type{T}, ::AbstractChar) where T<:Number at char.jl:180
  convert(::Type{T}, ::CartesianIndex{1}) where T<:Number at multidimensional.jl:136
  ...
Stacktrace:
 [1] Angle2d{Float64}(theta::NTuple{4, Float64})
   @ Rotations ~/.julia/dev/Rotations/src/core_types.jl:163
 [2] _construct_sametype
   @ ~/.julia/dev/StaticArrays/src/linalg.jl:97 [inlined]
 [3] _one(s::Size{(2, 2)}, m_or_SM::Angle2d{Float64})
   @ StaticArrays ~/.julia/dev/StaticArrays/src/linalg.jl:106
 [4] one(m::Angle2d{Float64})
   @ StaticArrays ~/.julia/dev/StaticArrays/src/linalg.jl:99
 [5] top-level scope
   @ REPL[10]:1

julia> one(RotXY(1,2))
ERROR: Cannot construct a two-axis rotation from a matrix
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] RotXY
   @ ~/.julia/dev/Rotations/src/euler_types.jl:240 [inlined]
 [3] _construct_sametype
   @ ~/.julia/dev/StaticArrays/src/linalg.jl:97 [inlined]
 [4] _one(s::Size{(3, 3)}, m_or_SM::RotXY{Float64})
   @ StaticArrays ~/.julia/dev/StaticArrays/src/linalg.jl:106
 [5] one(m::RotXY{Float64})
   @ StaticArrays ~/.julia/dev/StaticArrays/src/linalg.jl:99
 [6] top-level scope
   @ REPL[29]:1
```


**After this PR**
```julia
julia> one(Angle2d(0.1))
2×2 Angle2d{Float64} with indices SOneTo(2)×SOneTo(2)(0.0):
 1.0  -0.0
 0.0   1.0

julia> one(RotXY(1,2))
3×3 RotXY{Float64} with indices SOneTo(3)×SOneTo(3)(0.0, 0.0):
  1.0  0.0   0.0
  0.0  1.0  -0.0
 -0.0  0.0   1.0
```