### PR TITLE
Provide a no-op `convert`

### DIFF
--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -28,6 +28,7 @@ rotation_angle(r::Rotation{3}) = rotation_angle(AngleAxis(r))
 rotation_axis(r::Rotation{3}) = rotation_axis(AngleAxis(r))
 
 # `convert` goes through the constructors, similar to e.g. `Number`
+Base.convert(::Type{R}, rot::R) where {N,R<:Rotation{N}} = rot
 Base.convert(::Type{R}, rot::Rotation{N}) where {N,R<:Rotation{N}} = R(rot)
 
 # Rotation matrices should be orthoginal/unitary. Only the operations we define,

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -438,6 +438,9 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
         aa = AngleAxis(θ, x, y, z, false)
         @test norm([aa.axis_x, aa.axis_y, aa.axis_z]) ≈ norm([x, y, z])
 
+        aa = AngleAxis(0.0, 0.0, 0.0, 0.0, false)
+        @test convert(typeof(aa), aa) === aa
+
         w, x, y, z = 1., 2., 3., 4.
         quat = UnitQuaternion(w, x, y, z)
         @test norm([quat.w, quat.x, quat.y, quat.z]) ≈ 1.


### PR DESCRIPTION
This should help performance, but it also resolved a subtle bug
that crops up if you perform autodiff with respect to AngleAxis
coordinates at the origin: sqrt(dual(0.0)) gives you NaNs.
Those cropped up because AngleAxis doesn't remember if you
called it with `normalize=false`.