### PR TITLE
Bump version to v1.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Rotations"
 uuid = "6038ab10-8711-5258-84ad-4b1120ba62dc"
-version = "1.0.4"
+version = "1.1.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
As commented [here](https://github.com/JuliaGeometry/Rotations.jl/issues/198#issuecomment-971362152), I'd like to release the next minor version `v1.1.0`.

The new features (and a deprecation) will be:
* Add `nearest_rotation` function (#186)
* Compatible with Quaternions.jl (#175, #191)
* Rename `UnitQuaternion` to `QuatRotation` (#201)
