### PR TITLE
Fix `RotMatrix{2}` with Unitful.jl

### DIFF
--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -125,12 +125,12 @@ end
 Base.@propagate_inbounds Base.getindex(r::RotMatrix, i::Int) = r.mat[i]
 @inline Base.Tuple(r::RotMatrix) = Tuple(r.mat)
 
-@inline RotMatrix(θ::Real) = RotMatrix{2}(θ)
-@inline function (::Type{RotMatrix{2}})(θ::Real)
+@inline RotMatrix(θ::Number) = RotMatrix{2}(θ)
+@inline function (::Type{RotMatrix{2}})(θ::Number)
     s, c = sincos(θ)
     RotMatrix(@SMatrix [c -s; s c])
 end
-@inline function RotMatrix{2,T}(θ::Real) where T
+@inline function RotMatrix{2,T}(θ::Number) where T
     s, c = sincos(θ)
     RotMatrix(@SMatrix T[c -s; s c])
 end

--- a/test/2d.jl
+++ b/test/2d.jl
@@ -18,6 +18,8 @@ using Unitful
         # don't extraneously contain those units (see issue #55)
         @test eltype(Angle2d(10u"°")) <: Real
         @test eltype(Angle2d(20u"rad")) <: Real
+        @test eltype(RotMatrix{2}(10u"°")) <: Real
+        @test eltype(RotMatrix{2}(20u"rad")) <: Real
     end
 
     ###############################


### PR DESCRIPTION
This PR solves #188.

**On the current master branch**
```julia
julia> using Rotations

julia> import Unitful.°

julia> RotMatrix{2}(1°)
ERROR: DimensionMismatch("No precise constructor for RotMatrix{2, T, L} where {T, L} found. Length of input was 1.")
Stacktrace:
 [1] (RotMatrix{2, T, L} where {T, L})(x::Tuple{Tuple{Tuple{Tuple{Unitful.Quantity{Int64, NoDims, Unitful.FreeUnits{(°,), NoDims, nothing}}}}}})
   @ StaticArrays ~/.julia/dev/StaticArrays/src/convert.jl:1
 [2] StaticArray (repeats 4 times)
   @ ~/.julia/dev/StaticArrays/src/convert.jl:4 [inlined]
 [3] top-level scope
   @ REPL[5]:1
```

**with this PR**
```julia
julia> using Rotations

julia> import Unitful.°

julia> RotMatrix{2}(1°)
2×2 RotMatrix2{Float64} with indices SOneTo(2)×SOneTo(2):
 0.999848   -0.0174524
 0.0174524   0.999848
```