### PR TITLE
Fix around `QuatRotation` for compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Rotations"
 uuid = "6038ab10-8711-5258-84ad-4b1120ba62dc"
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -41,11 +41,11 @@ end
 function Base.getproperty(q::QuatRotation, f::Symbol)
     if f === :w
         q.q.s
-    elseif f == :x
+    elseif f === :x
         q.q.v1
-    elseif f == :y
+    elseif f === :y
         q.q.v2
-    elseif f == :z
+    elseif f === :z
         q.q.v3
     else
         getfield(q,f)

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -39,7 +39,7 @@ struct QuatRotation{T} <: Rotation{3,T}
 end
 
 function Base.getproperty(q::QuatRotation, f::Symbol)
-    if f == :w
+    if f === :w
         q.q.s
     elseif f == :x
         q.q.v1

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -38,6 +38,20 @@ struct QuatRotation{T} <: Rotation{3,T}
     QuatRotation{T}(q::QuatRotation) where T = new{T}(q.q)
 end
 
+function Base.getproperty(q::QuatRotation, f::Symbol)
+    if f == :w
+        q.q.s
+    elseif f == :x
+        q.q.v1
+    elseif f == :y
+        q.q.v2
+    elseif f == :z
+        q.q.v3
+    else
+        getfield(q,f)
+    end
+end
+
 # ~~~~~~~~~~~~~~~ Constructors ~~~~~~~~~~~~~~~ #
 # Use default map
 function QuatRotation(w,x,y,z, normalize::Bool = true)

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -260,17 +260,17 @@ end
 
 # Exponentials and Logarithms
 """
-    _pure_quaternion(v::AbstractVector)
-    _pure_quaternion(x, y, z)
+    pure_quaternion(v::AbstractVector)
+    pure_quaternion(x, y, z)
 
 Create a `Quaternion` with zero scalar part (i.e. `q.q.s == 0`).
 """
-function _pure_quaternion(v::AbstractVector)
+function pure_quaternion(v::AbstractVector)
     check_length(v, 3)
     Quaternion(zero(eltype(v)), v[1], v[2], v[3], false)
 end
 
-@inline _pure_quaternion(x::Real, y::Real, z::Real) =
+@inline pure_quaternion(x::Real, y::Real, z::Real) =
     Quaternion(zero(x), x, y, z, false)
 
 function expm(ϕ::AbstractVector)
@@ -294,7 +294,7 @@ function _log_as_quat(q::Q, eps=1e-6) where Q <: QuatRotation
     else
         M = (1-(θ^2/(3w^2)))/w
     end
-    _pure_quaternion(M*vector(q))
+    pure_quaternion(M*vector(q))
 end
 
 function logm(q::QuatRotation)

--- a/test/rodrigues_params.jl
+++ b/test/rodrigues_params.jl
@@ -67,7 +67,7 @@ end
     @test qdot ≈ 0.5*lmult(q)*hmat(ω)
     @test ω ≈ 2*vmat()*lmult(q)'qdot
     @test ω ≈ 2*vmat()*lmult(inv(q))*qdot
-    q2 = Quaternion(q)*_pure_quaternion(ω)
+    q2 = Quaternion(q)*pure_quaternion(ω)
     @test qdot ≈ SVector(q2.s, q2.v1, q2.v2, q2.v3)/2
 
     # MRPs

--- a/test/unitquat.jl
+++ b/test/unitquat.jl
@@ -21,10 +21,11 @@ import Rotations: vmat, rmult, lmult, hmat, tmat
     q32 = SVector{4,Float32}(q)
     @test QuatRotation(q) isa QuatRotation{Float64}
     @test QuatRotation(q32) isa QuatRotation{Float32}
-    @test q.w == q.q.s
-    @test q.x == q.q.v1
-    @test q.y == q.q.v2
-    @test q.z == q.q.v3
+    r = QuatRotation(q)
+    @test r.w == r.q.s
+    @test r.x == r.q.v1
+    @test r.y == r.q.v2
+    @test r.z == r.q.v3
 
     r = @SVector rand(3)
     r32 = SVector{3,Float32}(r)

--- a/test/unitquat.jl
+++ b/test/unitquat.jl
@@ -1,7 +1,7 @@
 using ForwardDiff
 
 import Rotations: jacobian, ∇rotate, ∇composition1, ∇composition2
-import Rotations: kinematics, _pure_quaternion, params
+import Rotations: kinematics, pure_quaternion, params
 import Rotations: vmat, rmult, lmult, hmat, tmat
 
 @testset "Unit Quaternions" begin
@@ -24,9 +24,9 @@ import Rotations: vmat, rmult, lmult, hmat, tmat
 
     r = @SVector rand(3)
     r32 = SVector{3,Float32}(r)
-    @test _pure_quaternion(r) isa Quaternion{Float64}
-    @test _pure_quaternion(r32) isa Quaternion{Float32}
-    @test real(_pure_quaternion(r)) == 0
+    @test pure_quaternion(r) isa Quaternion{Float64}
+    @test pure_quaternion(r32) isa Quaternion{Float32}
+    @test real(pure_quaternion(r)) == 0
 
     @test QuatRotation{Float64}(1, 0, 0, 0) isa QuatRotation{Float64}
     @test QuatRotation{Float32}(1, 0, 0, 0) isa QuatRotation{Float32}
@@ -52,7 +52,7 @@ import Rotations: vmat, rmult, lmult, hmat, tmat
 
     ϕ = inv(ExponentialMap())(q1)
     @test expm(ϕ * 2) ≈ q1
-    q = Rotations._pure_quaternion(ϕ)
+    q = Rotations.pure_quaternion(ϕ)
     @test QuatRotation(exp(q)) ≈ q1
     @test exp(q) isa Quaternion
 
@@ -83,7 +83,7 @@ import Rotations: vmat, rmult, lmult, hmat, tmat
     @test q3 ⊖ q2 ≈ inv(CayleyMap())(q1)
 
     q = q1
-    rhat = Rotations._pure_quaternion(r)
+    rhat = Rotations.pure_quaternion(r)
     @test q * r ≈ vmat() * lmult(q) * rmult(q)' * vmat()'r
     @test q * r ≈ vmat() * lmult(q) * rmult(q)' * hmat(r)
     @test q * r ≈ vmat() * lmult(q) * lmult(rhat) * tmat() * params(q)
@@ -92,7 +92,7 @@ import Rotations: vmat, rmult, lmult, hmat, tmat
 
     @test rmult(params(q)) == rmult(q)
     @test lmult(params(q)) == lmult(q)
-    r_pure = _pure_quaternion(r)
+    r_pure = pure_quaternion(r)
     @test hmat(r) == SVector(r_pure.s, r_pure.v1, r_pure.v2, r_pure.v3)
 
     # Test Jacobians

--- a/test/unitquat.jl
+++ b/test/unitquat.jl
@@ -21,6 +21,10 @@ import Rotations: vmat, rmult, lmult, hmat, tmat
     q32 = SVector{4,Float32}(q)
     @test QuatRotation(q) isa QuatRotation{Float64}
     @test QuatRotation(q32) isa QuatRotation{Float32}
+    @test q.w == q.q.s
+    @test q.x == q.q.v1
+    @test q.y == q.q.v2
+    @test q.z == q.q.v3
 
     r = @SVector rand(3)
     r32 = SVector{3,Float32}(r)


### PR DESCRIPTION
As discussed [here](https://github.com/JuliaGeometry/Rotations.jl/issues/208#issuecomment-976082837), it's better to keep `getproperty` method.

And also, this PR reverts the `pure_quaternion` method. (https://github.com/RoboticExplorationLab/RobotDynamics.jl/issues/12)