### PR TITLE
Add `Rotations.params` methods for `RotationGenerator`

### DIFF
--- a/src/rotation_generator.jl
+++ b/src/rotation_generator.jl
@@ -156,6 +156,7 @@ end
     end
 end
 
+@inline params(r::Angle2dGenerator) = SVector{1}(r.v)
 
 """
     struct RotationVecGenerator{T} <: RotationGenerator{2,T}
@@ -216,6 +217,7 @@ end
     end
 end
 
+@inline params(r::RotationVecGenerator) = SVector{3}(r.x,r.y,r.z)
 
 ################################################################################
 ################################################################################

--- a/test/rotation_generator.jl
+++ b/test/rotation_generator.jl
@@ -170,6 +170,11 @@
         @test_throws DimensionMismatch Angle2dGenerator(1) + RotationVecGenerator(2,3,4)
     end
 
+    @testset "params" begin
+        @test Rotations.params(Angle2dGenerator(1)) == [1]
+        @test Rotations.params(RotationVecGenerator(2,3,4)) == [2,3,4]
+    end
+
     @testset "type promotion" begin
         for (T, N) in ((Angle2dGenerator, 2), (RotationVecGenerator, 3))
             R = RotMatrixGenerator


### PR DESCRIPTION
This PR fixes #213.

**Before this PR**
```julia
julia> using Rotations

julia> RotationVecGenerator(1,2,3)
3×3 RotationVecGenerator{Int64} with indices SOneTo(3)×SOneTo(3)(1, 2, 3):
  0  -3   2
  3   0  -1
 -2   1   0

julia> Rotations.params(RotationVecGenerator(1,2,3))
ERROR: MethodError: no method matching params(::RotationVecGenerator{Int64})
Closest candidates are:
  params(::RotZY) at ~/.julia/dev/Rotations/src/euler_types.jl:259
  params(::AngleAxis) at ~/.julia/dev/Rotations/src/angleaxis_types.jl:40
  params(::RotY) at ~/.julia/dev/Rotations/src/euler_types.jl:37
  ...
Stacktrace:
 [1] top-level scope
   @ REPL[4]:1
```


**After this PR**
```julia
julia> using Rotations

julia> RotationVecGenerator(1,2,3)
3×3 RotationVecGenerator{Int64} with indices SOneTo(3)×SOneTo(3)(1, 2, 3):
  0  -3   2
  3   0  -1
 -2   1   0

julia> Rotations.params(RotationVecGenerator(1,2,3))
3-element StaticArrays.SVector{3, Int64} with indices SOneTo(3):
 1
 2
 3
```

