### PR TITLE
Add support for higher dimensional rotation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -34,6 +34,7 @@ makedocs(;
         "Common Methods for Rotations" => "functions.md",
         "Visualizing Rotations" => "visualizing.md",
         "Function Reference" => "functionreference.md",
+        "References" => "reference.md",
     ],
 )
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -30,6 +30,7 @@ makedocs(;
             "2D Rotation Generators" => "2d_rotation_generator.md",
             "3D Rotation Generators" => "3d_rotation_generator.md",
             ],
+        "General Dimensional Rotations" => "general_dimensional_rotations.md",
         "Common Methods for Rotations" => "functions.md",
         "Visualizing Rotations" => "visualizing.md",
         "Function Reference" => "functionreference.md",

--- a/docs/src/general_dimensional_rotations.md
+++ b/docs/src/general_dimensional_rotations.md
@@ -1,0 +1,20 @@
+# General dimensional Rotation
+
+Our main goal is to efficiently represent rotations in lower dimensions, such as 2D and 3D, but some operations on rotations in general dimensions are also supported.
+
+```@setup rotmatrixN
+using Rotations
+using StaticArrays
+```
+
+**example**
+
+```@repl rotmatrixN
+r1 = one(RotMatrix{4})  # generate identity rotation matrix
+m = @SMatrix rand(4,4)
+r2 = nearest_rotation(m)  # nearest rotation matrix from given matrix
+r3 = rand(RotMatrix{4})  # random rotation in SO(4)
+r1*r2/r3  # multiplication and division
+s = log(r2)  # logarithm of RotMatrix is a RotMatrixGenerator
+exp(s)  # exponential of RotMatrixGenerator is a RotMatrix
+```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -13,9 +13,9 @@
 * [Rotation matrix](https://en.wikipedia.org/wiki/Rotation_matrix)
 * [Quaternion](https://en.wikipedia.org/wiki/Quaternion)
 * [Wahba's problem](https://en.wikipedia.org/wiki/Wahba%27s_problem)
-    * Wahba's problem is related with `nearest_rotation` funciton.
+    * Wahba's problem is related to the `nearest_rotation` function.
 * [Polar decomposition](https://en.wikipedia.org/wiki/Polar_decomposition)
-    * Polar decomposition is also related with `nearest_rotation` funciton.
+    * Polar decomposition is also related to the `nearest_rotation` function.
 
 ## Others
 * ["Quaternions and 3d rotation, explained interactively" by 3Blue1Brown](https://www.youtube.com/watch?v=zjMuIxRvygQ)

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,4 +1,22 @@
 # Reference for rotations
 
-* [Quaternion (Wikipedia)](https://en.wikipedia.org/wiki/Quaternion)
-* [Quaternions and 3d rotation, explained interactively (by 3Blue1Brown)](https://www.youtube.com/watch?v=zjMuIxRvygQ)
+## Published articles
+* ["Fundamentals of Spacecraft Attitude Determination and Control" by Markley and Crassidis](https://link.springer.com/book/10.1007/978-1-4939-0802-8)
+    * See sections 2.1-2.9 for 3d rotation parametrization.
+    * See sections 3.1-3.2 for kinematics.
+* ["Derivation of the Euler-Rodrigues formula for three-dimensional rotations from the general formula for four-dimensional rotations" by Johan Ernest Mebius](https://arxiv.org/abs/math/0701759)
+    * The conversion `RotMatrix{3}` to `QuatRotaiton` is based on this paper.
+* ["Computing Exponentials of Skew Symmetric Matrices And Logarithms of Orthogonal Matrices" by Jean Gallier and Dianna Xu](https://cs.brynmawr.edu/~dxu/206-2550-2.pdf)
+    * See this article for log and exp of rotation matrices in higher dimensions.
+
+## Wikipedia articles
+* [Rotation matrix](https://en.wikipedia.org/wiki/Rotation_matrix)
+* [Quaternion](https://en.wikipedia.org/wiki/Quaternion)
+* [Wahba's problem](https://en.wikipedia.org/wiki/Wahba%27s_problem)
+    * Wahba's problem is related with `nearest_rotation` funciton.
+* [Polar decomposition](https://en.wikipedia.org/wiki/Polar_decomposition)
+    * Polar decomposition is also related with `nearest_rotation` funciton.
+
+## Others
+* ["Quaternions and 3d rotation, explained interactively" by 3Blue1Brown](https://www.youtube.com/watch?v=zjMuIxRvygQ)
+* ["Visualizing quaternions (4d numbers) with stereographic projection" by 3Blue1Brown](https://www.youtube.com/watch?v=d4EgbgTm0Bg)

--- a/docs/src/rotation_generator_types.md
+++ b/docs/src/rotation_generator_types.md
@@ -30,12 +30,12 @@ For more information, see the sidebar page.
 
 ### 2D rotations
 * `RotMatrixGenerator2{T}`
-    * Rotation matrix in 2 dimensional Euclidean space.
+    * Skew symmetric matrix in 2 dimensional Euclidean space.
 * `Angle2dGenerator`
-    * Parametrized with rotational angle.
+    * Parametrized with one real number like `Angle2d`.
 
 ### 3D rotations
 * `RotMatrixGenerator3{T}`
-    * Rotation matrix in 3 dimensional Euclidean space.
+    * Skew symmetric matrix in 3 dimensional Euclidean space.
 * `RotationVecGenerator`
-    * Rotation around given axis. The length of axis vector represents its angle.
+    * Rotation generator around given axis. The length of axis vector represents its angle.

--- a/src/Rotations.jl
+++ b/src/Rotations.jl
@@ -27,6 +27,7 @@ include("rotation_error.jl")
 include("rotation_generator.jl")
 include("logexp.jl")
 include("eigen.jl")
+include("rand.jl")
 include("deprecated.jl")
 
 export

--- a/src/Rotations.jl
+++ b/src/Rotations.jl
@@ -57,8 +57,10 @@ export
     # Quaternion maps
     ExponentialMap, QuatVecMap, CayleyMap, MRPMap, IdentityMap,
 
-    # check validity of the rotation (is it close to unitary?)
+    # check validity of the rotation (is it close to orthonormal?)
     isrotation,
+    # check validity of the rotation (is it skew-symmetric?)
+    isrotationgenerator,
 
     # Get nearest rotation matrix
     nearest_rotation,

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -98,18 +98,27 @@ RotMatrix(x::SMatrix{N,N,T,L}) where {N,T,L} = RotMatrix{N,T,L}(x)
 
 Base.zero(::Type{RotMatrix}) = error("The dimension of rotation is not specified.")
 
-# These functions (plus size) are enough to satisfy the entire StaticArrays interface:
 for N = 2:3
     L = N*N
     RotMatrixN = Symbol(:RotMatrix, N)
     @eval begin
-        @inline RotMatrix(t::NTuple{$L})  = RotMatrix(SMatrix{$N,$N}(t))
-        @inline (::Type{RotMatrix{$N}})(t::NTuple{$L}) = RotMatrix(SMatrix{$N,$N}(t))
-        @inline RotMatrix{$N,T}(t::NTuple{$L}) where {T} = RotMatrix(SMatrix{$N,$N,T}(t))
-        @inline RotMatrix{$N,T,$L}(t::NTuple{$L}) where {T} = RotMatrix(SMatrix{$N,$N,T}(t))
         const $RotMatrixN{T} = RotMatrix{$N, T, $L}
     end
 end
+
+# These functions (plus size) are enough to satisfy the entire StaticArrays interface:
+@inline function RotMatrix(t::NTuple{L}) where L
+    n = sqrt(L)
+    if !isinteger(n)
+        throw(DimensionMismatch("The length of input tuple $(t) must be square number."))
+    end
+    N = Int(n)
+    RotMatrix(SMatrix{N,N}(t))
+end
+@inline (::Type{RotMatrix{N}})(t::NTuple) where N = RotMatrix(SMatrix{N,N}(t))
+@inline RotMatrix{N,T}(t::NTuple) where {N,T} = RotMatrix(SMatrix{N,N,T}(t))
+@inline RotMatrix{N,T,L}(t::NTuple{L}) where {N,T,L} = RotMatrix(SMatrix{N,N,T}(t))
+
 Base.@propagate_inbounds Base.getindex(r::RotMatrix, i::Int) = r.mat[i]
 @inline Base.Tuple(r::RotMatrix) = Tuple(r.mat)
 

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -40,28 +40,6 @@ Base.convert(::Type{R}, rot::Rotation{N}) where {N,R<:Rotation{N}} = R(rot)
 Base.@pure StaticArrays.similar_type(::Union{R,Type{R}}) where {R <: Rotation} = SMatrix{size(R)..., eltype(R), prod(size(R))}
 Base.@pure StaticArrays.similar_type(::Union{R,Type{R}}, ::Type{T}) where {R <: Rotation, T} = SMatrix{size(R)..., T, prod(size(R))}
 
-function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Rotation{2}
-    T = eltype(R)
-    if T == Any
-        T = Float64
-    end
-
-    R(2π * rand(rng, T))
-end
-
-# A random rotation can be obtained easily with unit quaternions
-# The unit sphere in R⁴ parameterizes quaternion rotations according to the
-# Haar measure of SO(3) - see e.g. http://math.stackexchange.com/questions/184086/uniform-distributions-on-the-space-of-rotations-in-3d
-function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Rotation{3}
-    T = eltype(R)
-    if T == Any
-        T = Float64
-    end
-
-    q = QuatRotation(randn(rng, T), randn(rng, T), randn(rng, T), randn(rng, T))
-    return R(q)
-end
-
 @inline function Base.:/(r1::Rotation, r2::Rotation)
     r1 * inv(r2)
 end
@@ -267,17 +245,6 @@ function nearest_rotation(M::AbstractMatrix{T}) where T
     L = N^2
     M_ = convert(SMatrix{N,N,T,L}, M)
     return nearest_rotation(M_)
-end
-
-# A random rotation can be obtained via random matrix and nearest_rotation.
-function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: RotMatrix{N} where N
-    T = eltype(R)
-    if T == Any
-        T = Float64
-    end
-
-    m = @SMatrix randn(N,N)
-    return nearest_rotation(m)
 end
 
 # A simplification and specialization of the Base.show function for AbstractArray makes

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -269,6 +269,17 @@ function nearest_rotation(M::AbstractMatrix{T}) where T
     return nearest_rotation(M_)
 end
 
+# A random rotation can be obtained via random matrix and nearest_rotation.
+function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: RotMatrix{N} where N
+    T = eltype(R)
+    if T == Any
+        T = Float64
+    end
+
+    m = @SMatrix randn(N,N)
+    return nearest_rotation(m)
+end
+
 # A simplification and specialization of the Base.show function for AbstractArray makes
 # everything sensible at the REPL.
 function Base.show(io::IO, ::MIME"text/plain", X::Rotation)

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -26,6 +26,10 @@ Base.zeros(::Type{R}, dims::Tuple{}) where {R<:Rotation} = zeros(typeof(zero(R))
 # Generate identity rotation matrix
 Base.one(r::Rotation) = one(typeof(r))
 
+# Rotation angles and axes can be obtained by converting to the AngleAxis type
+rotation_angle(r::Rotation{3}) = rotation_angle(AngleAxis(r))
+rotation_axis(r::Rotation{3}) = rotation_axis(AngleAxis(r))
+
 # `convert` goes through the constructors, similar to e.g. `Number`
 Base.convert(::Type{R}, rot::R) where {N,R<:Rotation{N}} = rot
 Base.convert(::Type{R}, rot::Rotation{N}) where {N,R<:Rotation{N}} = R(rot)
@@ -171,6 +175,13 @@ Angle2d{T}(r::Rotation{2}) where {T} = Angle2d{T}(rotation_angle(r))
 
 Base.one(::Type{A}) where {A<: Angle2d} = A(0)
 
+rotation_angle(rot::Angle2d) = rot.theta
+function rotation_angle(rot::Rotation{2})
+    c = @inbounds rot[1,1]
+    s = @inbounds rot[2,1]
+    atan(s, c)
+end
+
 @inline function Base.:*(r::Angle2d, v::StaticVector)
     if length(v) != 2
         throw(DimensionMismatch("Cannot rotate a vector of length $(length(v))"))
@@ -202,25 +213,6 @@ end
 
 ################################################################################
 ################################################################################
-
-# 2-dimensional rotation rotation_angle
-rotation_angle(r::Angle2d) = r.theta
-function rotation_angle(r::RotMatrix{2})
-    c = @inbounds r[1,1]
-    s = @inbounds r[2,1]
-    return atan(s, c)
-end
-
-# 3-dimensional rotation angles and axes can be obtained by converting to the AngleAxis type
-rotation_angle(r::Rotation{3}) = rotation_angle(AngleAxis(r))
-rotation_angle(r::RotMatrix{3}) = rotation_angle(AngleAxis(r)) # avoid general dimensional definition
-rotation_axis(r::Rotation{3}) = rotation_axis(AngleAxis(r))
-
-# N-dimensional rotation angles can be obtained by logarithm (RotMatrixGenerator)
-function rotation_angle(r::RotMatrix{N,T}) where {N,T}
-    s = log(r)
-    return norm(s)/sqrt(T(2))
-end
 
 _isrotation_eps(T::Type{<:Integer}) = zero(T)
 _isrotation_eps(T) = eps(T)

--- a/src/euler_types.jl
+++ b/src/euler_types.jl
@@ -38,16 +38,6 @@ for axis in [:X, :Y, :Z]
     end
 end
 
-function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Union{RotX,RotY,RotZ}
-    T = eltype(R)
-    if T == Any
-        T = Float64
-    end
-
-    return R(2π*rand(rng, T))
-end
-
-
 """
     struct RotX{T} <: Rotation{3,T}
     RotX(theta)
@@ -260,19 +250,6 @@ for axis1 in [:X, :Y, :Z]
         end
     end
 end
-
-function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Union{RotXY,RotYZ,RotZX, RotXZ, RotYX, RotZY}
-    T = eltype(R)
-    if T == Any
-        T = Float64
-    end
-
-    # Not really sure what this distribution is, but it's also not clear what
-    # it should be! rand(RotXY) *is* invariant to pre-rotations by a RotX and
-    # post-rotations by a RotY...
-    return R(2π*rand(rng, T), 2π*rand(rng, T))
-end
-
 
 """
     struct RotXY{T} <: Rotation{3,T}

--- a/src/logexp.jl
+++ b/src/logexp.jl
@@ -10,8 +10,11 @@ Base.log(R::Rotation{3}) = log(RotationVec(R))
 Base.log(R::RotMatrix{3}) = RotMatrixGenerator(log(RotationVec(R)))
 
 # General dimensions
-# This will be faster when log(::SMatrix) is implemented in StaticArrays.jl
-Base.log(R::RotMatrix{N}) where N = RotMatrixGenerator(SMatrix{N,N}(log(Matrix(R))))
+function Base.log(R::RotMatrix{N}) where N
+    # This will be faster when log(::SMatrix) is implemented in StaticArrays.jl
+    S = SMatrix{N,N}(log(Matrix(R)))
+    RotMatrixGenerator((S-S')/2)
+end
 
 ## exp
 # 2d

--- a/src/logexp.jl
+++ b/src/logexp.jl
@@ -10,20 +10,17 @@ Base.log(R::Rotation{3}) = log(RotationVec(R))
 Base.log(R::RotMatrix{3}) = RotMatrixGenerator(log(RotationVec(R)))
 
 # General dimensions
-if VERSION < v"1.7"
-    # This if block is related to this PR.
-    # https://github.com/JuliaLang/julia/pull/40573
-    function Base.log(R::RotMatrix{N}) where N
-        # This will be faster when log(::SMatrix) is implemented in StaticArrays.jl
+function Base.log(R::RotMatrix{N}) where N
+    # This will be faster when log(::SMatrix) is implemented in StaticArrays.jl
+    @static if VERSION < v"1.7"
+        # This if block is related to this PR.
+        # https://github.com/JuliaLang/julia/pull/40573
         S = SMatrix{N,N}(real(log(Matrix(R))))
-        RotMatrixGenerator((S-S')/2)
-    end
-else
-    function Base.log(R::RotMatrix{N}) where N
-        # This will be faster when log(::SMatrix) is implemented in StaticArrays.jl
+    else
         S = SMatrix{N,N}(log(Matrix(R)))
-        RotMatrixGenerator((S-S')/2)
     end
+    RotMatrixGenerator((S-S')/2)
+end
 end
 
 ## exp

--- a/src/logexp.jl
+++ b/src/logexp.jl
@@ -10,10 +10,20 @@ Base.log(R::Rotation{3}) = log(RotationVec(R))
 Base.log(R::RotMatrix{3}) = RotMatrixGenerator(log(RotationVec(R)))
 
 # General dimensions
-function Base.log(R::RotMatrix{N}) where N
-    # This will be faster when log(::SMatrix) is implemented in StaticArrays.jl
-    S = SMatrix{N,N}(log(Matrix(R)))
-    RotMatrixGenerator((S-S')/2)
+if VERSION < v"1.7"
+    # This if block is related to this PR.
+    # https://github.com/JuliaLang/julia/pull/40573
+    function Base.log(R::RotMatrix{N}) where N
+        # This will be faster when log(::SMatrix) is implemented in StaticArrays.jl
+        S = SMatrix{N,N}(real(log(Matrix(R))))
+        RotMatrixGenerator((S-S')/2)
+    end
+else
+    function Base.log(R::RotMatrix{N}) where N
+        # This will be faster when log(::SMatrix) is implemented in StaticArrays.jl
+        S = SMatrix{N,N}(log(Matrix(R)))
+        RotMatrixGenerator((S-S')/2)
+    end
 end
 
 ## exp

--- a/src/logexp.jl
+++ b/src/logexp.jl
@@ -1,13 +1,16 @@
 ## log
 # 2d
 Base.log(R::Angle2d) = Angle2dGenerator(R.theta)
-Base.log(R::Rotation{2}) = log(Angle2d(R))
 Base.log(R::RotMatrix{2}) = RotMatrixGenerator(log(Angle2d(R)))
+#= We can define log for Rotation{2} like this,
+but the subtypes of Rotation{2} are only Angle2d and RotMatrix{2},
+so we don't need this defnition. =#
+# Base.log(R::Rotation{2}) = log(Angle2d(R))
 
 # 3d
 Base.log(R::RotationVec) = RotationVecGenerator(R.sx,R.sy,R.sz)
-Base.log(R::Rotation{3}) = log(RotationVec(R))
 Base.log(R::RotMatrix{3}) = RotMatrixGenerator(log(RotationVec(R)))
+Base.log(R::Rotation{3}) = log(RotationVec(R))
 
 # General dimensions
 function Base.log(R::RotMatrix{N}) where N
@@ -25,13 +28,15 @@ end
 ## exp
 # 2d
 Base.exp(R::Angle2dGenerator) = Angle2d(R.v)
-Base.exp(R::RotationGenerator{2}) = exp(Angle2dGenerator(R))
 Base.exp(R::RotMatrixGenerator{2}) = RotMatrix(exp(Angle2dGenerator(R)))
+# Same as log(R::Rotation{2}), this definition is not necessary until someone add a new subtype of RotationGenerator{2}.
+# Base.exp(R::RotationGenerator{2}) = exp(Angle2dGenerator(R))
 
 # 3d
 Base.exp(R::RotationVecGenerator) = RotationVec(R.x,R.y,R.z)
-Base.exp(R::RotationGenerator{3}) = exp(RotationVecGenerator(R))
 Base.exp(R::RotMatrixGenerator{3}) = RotMatrix(exp(RotationVecGenerator(R)))
+# Same as log(R::Rotation{2}), this definition is not necessary until someone add a new subtype of RotationGenerator{3}.
+# Base.exp(R::RotationGenerator{3}) = exp(RotationVecGenerator(R))
 
 # General dimensions
 Base.exp(R::RotMatrixGenerator{N}) where N = RotMatrix(exp(SMatrix(R)))

--- a/src/logexp.jl
+++ b/src/logexp.jl
@@ -1,49 +1,28 @@
 ## log
-# 3d
-function Base.log(R::RotationVec)
-    x, y, z = params(R)
-    return RotationVecGenerator(x,y,z)
-end
-
-function Base.log(R::Rotation{3})
-    log(RotationVec(R))
-end
-
-
 # 2d
-function Base.log(R::Angle2d)
-    θ, = params(R)
-    return Angle2dGenerator(θ)
-end
+Base.log(R::Angle2d) = Angle2dGenerator(R.theta)
+Base.log(R::Rotation{2}) = log(Angle2d(R))
+Base.log(R::RotMatrix{2}) = RotMatrixGenerator(log(Angle2d(R)))
 
-function Base.log(R::Rotation{2})
-    log(Angle2d(R))
-end
+# 3d
+Base.log(R::RotationVec) = RotationVecGenerator(R.sx,R.sy,R.sz)
+Base.log(R::Rotation{3}) = log(RotationVec(R))
+Base.log(R::RotMatrix{3}) = RotMatrixGenerator(log(RotationVec(R)))
 
+# General dimensions
+# This will be faster when log(::SMatrix) is implemented in StaticArrays.jl
+Base.log(R::RotMatrix{N}) where N = RotMatrixGenerator(SMatrix{N,N}(log(Matrix(R))))
 
 ## exp
-# 3d
-function Base.exp(R::RotationVecGenerator)
-    return RotationVec(R.x,R.y,R.z)
-end
-
-function Base.exp(R::RotationGenerator{3})
-    exp(RotationVecGenerator(R))
-end
-
-function Base.exp(R::RotMatrixGenerator{3})
-    RotMatrix(exp(RotationVecGenerator(R)))
-end
-
 # 2d
-function Base.exp(R::Angle2dGenerator)
-    return Angle2d(R.v)
-end
+Base.exp(R::Angle2dGenerator) = Angle2d(R.v)
+Base.exp(R::RotationGenerator{2}) = exp(Angle2dGenerator(R))
+Base.exp(R::RotMatrixGenerator{2}) = RotMatrix(exp(Angle2dGenerator(R)))
 
-function Base.exp(R::RotationGenerator{2})
-    exp(Angle2dGenerator(R))
-end
+# 3d
+Base.exp(R::RotationVecGenerator) = RotationVec(R.x,R.y,R.z)
+Base.exp(R::RotationGenerator{3}) = exp(RotationVecGenerator(R))
+Base.exp(R::RotMatrixGenerator{3}) = RotMatrix(exp(RotationVecGenerator(R)))
 
-function Base.exp(R::RotMatrixGenerator{2})
-    RotMatrix(exp(Angle2dGenerator(R)))
-end
+# General dimensions
+Base.exp(R::RotMatrixGenerator{N}) where N = RotMatrix(exp(SMatrix(R)))

--- a/src/logexp.jl
+++ b/src/logexp.jl
@@ -21,7 +21,6 @@ function Base.log(R::RotMatrix{N}) where N
     end
     RotMatrixGenerator((S-S')/2)
 end
-end
 
 ## exp
 # 2d

--- a/src/mrps.jl
+++ b/src/mrps.jl
@@ -25,9 +25,6 @@ MRP(x::X, y::Y, z::Z) where {X,Y,Z} = MRP{promote_type(X,Y,Z)}(x, y, z)
 params(g::MRP) = SVector{3}(g.x, g.y, g.z)
 
 # ~~~~~~~~~~~~~~~ Initializers ~~~~~~~~~~~~~~~ #
-function Random.rand(rng::AbstractRNG, ::Random.SamplerType{RP}) where RP <: MRP
-    RP(rand(rng, QuatRotation))
-end
 Base.one(::Type{RP}) where RP <: MRP = RP(0.0, 0.0, 0.0)
 
 # ~~~~~~~~~~~~~~~~ Quaternion <=> MRP ~~~~~~~~~~~~~~~~~~ #

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -1,6 +1,6 @@
 function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Union{<:Rotation{2},<:RotMatrix{2}}
-    # Union{<:Rotation{2},<:RotMatrix{2}} seems able to be replaced with Rotation{2},
-    # but it avoids the method for general dimensional RotMatrix.
+    # We use the awkward Union{<:Rotation{2},<:RotMatrix{2}} here rather than `Rotation{2}`
+    # to make this efficient 2D method more specific than the method for general `RotMatrix`.
     T = eltype(R)
     if T == Any
         T = Float64
@@ -13,8 +13,8 @@ end
 # The unit sphere in R⁴ parameterizes quaternion rotations according to the
 # Haar measure of SO(3) - see e.g. http://math.stackexchange.com/questions/184086/uniform-distributions-on-the-space-of-rotations-in-3d
 function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Union{<:Rotation{3},<:RotMatrix{3}}
-    # Union{<:Rotation{3},<:RotMatrix{3}} seems able to be replaced with Rotation{3},
-    # but it avoids the method for general dimensional RotMatrix.
+    # We use the awkward Union{<:Rotation{2},<:RotMatrix{2}} here rather than `Rotation{2}`
+    # to make this efficient 3D method more specific than the method for general `RotMatrix`.
     T = eltype(R)
     if T == Any
         T = Float64

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -1,4 +1,6 @@
-function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Rotation{2}
+function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Union{<:Rotation{2},<:RotMatrix{2}}
+    # Union{<:Rotation{2},<:RotMatrix{2}} seems meaningless,
+    # but it avoids the method for general dimensional RotMatrix
     T = eltype(R)
     if T == Any
         T = Float64
@@ -10,7 +12,9 @@ end
 # A random rotation can be obtained easily with unit quaternions
 # The unit sphere in R⁴ parameterizes quaternion rotations according to the
 # Haar measure of SO(3) - see e.g. http://math.stackexchange.com/questions/184086/uniform-distributions-on-the-space-of-rotations-in-3d
-function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Rotation{3}
+function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Union{<:Rotation{3},<:RotMatrix{3}}
+    # Union{<:Rotation{3},<:RotMatrix{3}} seems meaningless,
+    # but it avoids the method for general dimensional RotMatrix
     T = eltype(R)
     if T == Any
         T = Float64

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -35,3 +35,36 @@ function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: RotMa
     m = randn(rng, SMatrix{N,N,T})
     return nearest_rotation(m)
 end
+
+function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Union{RotX,RotY,RotZ}
+    T = eltype(R)
+    if T == Any
+        T = Float64
+    end
+
+    return R(2π*rand(rng, T))
+end
+
+function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Union{RotXY,RotYZ,RotZX, RotXZ, RotYX, RotZY}
+    T = eltype(R)
+    if T == Any
+        T = Float64
+    end
+
+    # Not really sure what this distribution is, but it's also not clear what
+    # it should be! rand(RotXY) *is* invariant to pre-rotations by a RotX and
+    # post-rotations by a RotY...
+    return R(2π*rand(rng, T), 2π*rand(rng, T))
+end
+
+function Random.rand(rng::AbstractRNG, ::Random.SamplerType{RP}) where RP <: MRP
+    RP(rand(rng, QuatRotation))
+end
+
+@inline function Random.rand(rng::AbstractRNG, ::Random.SamplerType{RP}) where RP <: RodriguesParam
+    RP(rand(rng, QuatRotation))
+end
+
+function Random.rand(rng::AbstractRNG, ::Random.SamplerType{<:QuatRotation{T}}) where T
+    _normalize(QuatRotation{T}(randn(rng,T), randn(rng,T), randn(rng,T), randn(rng,T)))
+end

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -1,0 +1,33 @@
+function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Rotation{2}
+    T = eltype(R)
+    if T == Any
+        T = Float64
+    end
+
+    R(2π * rand(rng, T))
+end
+
+# A random rotation can be obtained easily with unit quaternions
+# The unit sphere in R⁴ parameterizes quaternion rotations according to the
+# Haar measure of SO(3) - see e.g. http://math.stackexchange.com/questions/184086/uniform-distributions-on-the-space-of-rotations-in-3d
+function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Rotation{3}
+    T = eltype(R)
+    if T == Any
+        T = Float64
+    end
+
+    q = QuatRotation(randn(rng, T), randn(rng, T), randn(rng, T), randn(rng, T))
+    return R(q)
+end
+
+# A random rotation can be obtained via random matrix and nearest_rotation.
+# This is slower than the implementation for 2 or 3 dimensions, but it is possible to create a random matrix on SO(n)
+function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: RotMatrix{N} where N
+    T = eltype(R)
+    if T == Any
+        T = Float64
+    end
+
+    m = @SMatrix randn(T,N,N)
+    return nearest_rotation(m)
+end

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -1,6 +1,6 @@
 function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Union{<:Rotation{2},<:RotMatrix{2}}
-    # Union{<:Rotation{2},<:RotMatrix{2}} seems meaningless,
-    # but it avoids the method for general dimensional RotMatrix
+    # Union{<:Rotation{2},<:RotMatrix{2}} seems able to be replaced with Rotation{2},
+    # but it avoids the method for general dimensional RotMatrix.
     T = eltype(R)
     if T == Any
         T = Float64
@@ -13,8 +13,8 @@ end
 # The unit sphere in R⁴ parameterizes quaternion rotations according to the
 # Haar measure of SO(3) - see e.g. http://math.stackexchange.com/questions/184086/uniform-distributions-on-the-space-of-rotations-in-3d
 function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Union{<:Rotation{3},<:RotMatrix{3}}
-    # Union{<:Rotation{3},<:RotMatrix{3}} seems meaningless,
-    # but it avoids the method for general dimensional RotMatrix
+    # Union{<:Rotation{3},<:RotMatrix{3}} seems able to be replaced with Rotation{3},
+    # but it avoids the method for general dimensional RotMatrix.
     T = eltype(R)
     if T == Any
         T = Float64

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -32,6 +32,6 @@ function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: RotMa
         T = Float64
     end
 
-    m = @SMatrix randn(T,N,N)
+    m = randn(rng, SMatrix{N,N,T})
     return nearest_rotation(m)
 end

--- a/src/rodrigues_params.jl
+++ b/src/rodrigues_params.jl
@@ -23,9 +23,6 @@ RodriguesParam(x::X, y::Y, z::Z) where {X,Y,Z} = RodriguesParam{promote_type(X,Y
 params(g::RodriguesParam) = SVector{3}(g.x, g.y, g.z)
 
 # ~~~~~~~~~~~~~~~ Initializers ~~~~~~~~~~~~~~~ #
-@inline function Random.rand(rng::AbstractRNG, ::Random.SamplerType{RP}) where RP <: RodriguesParam
-    RP(rand(rng, QuatRotation))
-end
 @inline Base.one(::Type{RP}) where RP <: RodriguesParam = RP(0.0, 0.0, 0.0)
 
 # ~~~~~~~~~~~~~~~ Quaternion <=> RP ~~~~~~~~~~~~~~~~~~ #

--- a/src/rotation_generator.jl
+++ b/src/rotation_generator.jl
@@ -261,7 +261,7 @@ function isrotationgenerator(r::StaticMatrix{N,N,T}) where {N,T<:Real}
 end
 
 function isrotationgenerator(r::AbstractMatrix{T}) where T<:Real
-    if !=(size(r)...)
+    if size(r,1) != size(r, 2)
         return false
     end
     return iszero(r+r')

--- a/src/rotation_generator.jl
+++ b/src/rotation_generator.jl
@@ -244,3 +244,30 @@ function Base.show(io::IO, ::MIME"text/plain", X::RotationGenerator)
     io = IOContext(io, :typeinfo => eltype(X))
     Base.print_array(io, X)
 end
+
+"""
+    isrotationgenerator(r)
+    isrotationgenerator(r, tol)
+
+Check whether `r` is a rotation generator matrix (skew-symmetric matrix).
+"""
+isrotationgenerator
+
+function isrotationgenerator(r::StaticMatrix{N,N,T}) where {N,T<:Real}
+    m = SMatrix(r)
+    return iszero(m+m')
+end
+
+function isrotationgenerator(r::AbstractMatrix{T}) where T<:Real
+    if !=(size(r)...)
+        return false
+    end
+    return iszero(r+r')
+end
+
+function isrotationgenerator(r::AbstractMatrix{T}) where T<:Number
+    if !isreal(r)
+        return false
+    end
+    return isrotationgenerator(real(r))
+end

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -234,9 +234,6 @@ Rotations.params(p) == @SVector [1.0, 2.0, 3.0]  # true
 @inline params(q::QuatRotation) = SVector{4}(q.q.s, q.q.v1, q.q.v2, q.q.v3)
 
 # ~~~~~~~~~~~~~~~ Initializers ~~~~~~~~~~~~~~~ #
-function Random.rand(rng::AbstractRNG, ::Random.SamplerType{<:QuatRotation{T}}) where T
-    _normalize(QuatRotation{T}(randn(rng,T), randn(rng,T), randn(rng,T), randn(rng,T)))
-end
 @inline Base.one(::Type{Q}) where Q <: QuatRotation = Q(1.0, 0.0, 0.0, 0.0)
 
 

--- a/test/distribution_tests.jl
+++ b/test/distribution_tests.jl
@@ -16,7 +16,7 @@ To visualize the distribution, try the following script.
     cdf_true(t) = t-sinpi(t)/π
 
     # Probability density function and histogram of sampling distribution
-    histogram(angles, normed = true, label=false)
+    histogram(angles, normed=true, label=false)
     plot!(t->1-cospi(t), 0, 1, label=false)
 
     # Cumulative distribution function
@@ -76,4 +76,25 @@ To visualize the distribution, try the following script.
         @test norm(cdf_true.(ts) - cdf_sampled.(ts), Inf) < 0.01
     end
 
+    @testset "distribution $(N)-dimensinal RotMatrix" for N in 2:5
+        # Sampling
+        RotType = RotMatrix{N}
+        n = 1000000
+        rs = rand(RotType, n)
+        q = rand(RotType)
+        norms1 = norm.([(r/q - one(SMatrix{N,N})) for r in rs])
+        norms2 = norm.([(r - one(SMatrix{N,N})) for r in rs])
+
+        # Check sampled rotations are rotations
+        @test all(isrotation.(rs))
+        @test isrotation(q)
+
+        # Cumulative distribution function
+        cdf_sampled1(t) = count(<(t), norms1)/n
+        cdf_sampled2(t) = count(<(t), norms2)/n
+
+        # Check the CDFs are approximately equal
+        ts = 0:0.01:1
+        @test norm(cdf_sampled1.(ts) - cdf_sampled2.(ts), Inf) < 0.01
+    end
 end

--- a/test/logexp.jl
+++ b/test/logexp.jl
@@ -13,6 +13,14 @@
         @test log(R) isa RotationGenerator
         @test exp(log(R)) isa Rotation
     end
+
+    @testset "$(N)-dim" for N in 1:5
+        M = @SMatrix rand(N,N)
+        R = nearest_rotation(M)
+        @test isrotationgenerator(log(R))
+        @test log(R) isa RotMatrixGenerator
+        @test exp(log(R)) isa RotMatrix
+    end
 end
 
 @testset "exp(zero)" begin

--- a/test/nearest_rotation.jl
+++ b/test/nearest_rotation.jl
@@ -1,5 +1,5 @@
 @testset "nearest_rotation" begin
-    @testset "$(N)-dim" for N in [2,3]
+    @testset "$(N)-dim" for N in [2,3,4]
         for _ in 1:100
             M = randn(N,N)
             R = nearest_rotation(M)

--- a/test/rotation_generator.jl
+++ b/test/rotation_generator.jl
@@ -194,6 +194,56 @@
         end
     end
 
+    #########################################################################
+    # Check that isrotationgenerator works
+    #########################################################################
+    @testset "Testing isrotationgenerator" begin
+        # Rotation generator around x-axis
+        a=[0.0 0.0 0.0
+           0.0 0.0 -1.0
+           0.0 1.0 0.0]
+        @test isrotationgenerator(a)
+
+        # Scaling in x-axis is not rotation generator
+        a=[4.0 0.0 0.0
+           0.0 0.0 0.0
+           0.0 0.0 0.0]
+        @test !isrotationgenerator(a)
+
+        # Non-square matrix is not rotation generator
+        @test !isrotationgenerator(zeros(2,3))
+        @test !isrotationgenerator(@SMatrix zeros(2,3))
+
+        # isrotationgenerator should work for integer
+        @test isrotationgenerator([0 1 0; -1 0 0; 0 0 0])
+
+        # zero matrix is rotation generator
+        @test isrotationgenerator(zeros(1,1))
+        @test isrotationgenerator(zeros(3,3))
+        @test isrotationgenerator(zeros(4,4))
+        @test isrotationgenerator(zero(SMatrix{1,1}))
+        @test isrotationgenerator(zero(SMatrix{3,3}))
+        @test isrotationgenerator(zero(SMatrix{4,4}))
+        @test isrotationgenerator(zero(RotMatrix{1}))
+        @test isrotationgenerator(zero(RotMatrix{3}))
+        @test isrotationgenerator(zero(RotMatrix{4}))
+
+        # Rotation matrix can be AbstractMatrix{<:Complex}
+        @test isrotationgenerator(zeros(3,3) .+ 0im)
+        @test isrotationgenerator(zero(SMatrix{4,4}) .+ 0im)
+
+        # Including NaNs are not rotaion
+        @test !isrotationgenerator(RotationVecGenerator(0, 0, NaN))
+        @test !isrotationgenerator(Angle2d(NaN))
+
+        # Complex unitary matrix is not rotation
+        M = randn(Complex{Float64},3,3)
+        @test !isrotationgenerator(M+M')
+        @test !isrotationgenerator(M+transpose(M))
+        @test !isrotationgenerator(real(M+M'))
+        @test !isrotationgenerator(real(M+transpose(M)))
+    end
+
     @testset "Testing show" begin
         io = IOBuffer()
         r = zero(RotMatrixGenerator{2})

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -307,18 +307,6 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
         # TODO RotX, RotXY?
     end
 
-    @testset "$(N)-dimensional rotation_angle" for N in 2:5
-        Random.seed!(0)
-        repeats = 100
-        for i in 1:repeats
-            angle = rand()
-            m = one(MMatrix{N,N})
-            m[1:2,1:2] = Angle2d(angle)
-            r = RotMatrix(m)
-            @test rotation_angle(r) ≈ angle
-        end
-    end
-
     #########################################################################
     # Check construction of QuatRotation given two vectors
     #########################################################################

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -307,6 +307,18 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
         # TODO RotX, RotXY?
     end
 
+    @testset "$(N)-dimensional rotation_angle" for N in 2:5
+        Random.seed!(0)
+        repeats = 100
+        for i in 1:repeats
+            angle = rand()
+            m = one(MMatrix{N,N})
+            m[1:2,1:2] = Angle2d(angle)
+            r = RotMatrix(m)
+            @test rotation_angle(r) ≈ angle
+        end
+    end
+
     #########################################################################
     # Check construction of QuatRotation given two vectors
     #########################################################################

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -403,30 +403,68 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
     # Check that isrotation works
     #########################################################################
     @testset "Testing isrotation" begin
+        # Rotate 90° around x-axis
         a=[1.0 0.0 0.0
            0.0 0.0 -1.0
            0.0 1.0 0.0]
         @test isrotation(a)
 
+        # Random generated Rotation must be rotation
         foreach(rot_types) do rot_type
             foreach(1:20) do idx
             @test isrotation(rand(rot_type))
             end
         end
 
-        a=[40.0 0.0 0.0
-           0.0 0.0 1.0
-           0.0 1.0 0.0]
+        # Scaling in x-axis is not rotation
+        a=[4.0 0.0 0.0
+           0.0 1.0 0.0
+           0.0 0.0 1.0]
         @test !isrotation(a)
 
+        # Flipping y-axis and z-axis is not rotation
         a=[1.0 0.0 0.0
            0.0 0.0 1.0
            0.0 1.0 0.0]
         @test !isrotation(a)
 
+        # Non-square matrix is not rotation
+        @test !isrotation(zeros(2,3))
+        @test !isrotation(@SMatrix zeros(2,3))
+
         # isrotation should work for integer (or boolean) matrices (issue #94)
         @test isrotation([0 1 0; -1 0 0; 0 0 1])
+
+        # identity matrix is rotation
+        @test isrotation(I(1))
+        @test isrotation(I(3))
+        @test isrotation(I(4))
+        @test isrotation(Matrix(I,1,1))
         @test isrotation(Matrix(I,3,3))
+        @test isrotation(Matrix(I,4,4))
+        @test isrotation(one(SMatrix{1,1}))
+        @test isrotation(one(SMatrix{3,3}))
+        @test isrotation(one(SMatrix{4,4}))
+        @test isrotation(one(RotMatrix{1}))
+        @test isrotation(one(RotMatrix{3}))
+        @test isrotation(one(RotMatrix{4}))
+
+        # Rotation matrix can be AbstractMatrix{<:Complex}
+        @test isrotation(I(3) .+ 0im)
+        @test isrotation(one(SMatrix{4,4}) .+ 0im)
+
+        # Including NaNs are not rotaion
+        @test !isrotation(MRP(0, 0, NaN))
+        @test !isrotation(RotXYZ(0, NaN, NaN))
+        @test !isrotation(RotX(NaN))
+        @test !isrotation(AngleAxis(1.,0.,0.,0.))
+        @test !isrotation(QuatRotation(0.,0.,0.,0.))
+
+        # Complex unitary matrix is not rotation
+        M = Hermitian(randn(Complex{Float64},3,3))
+        A = eigvecs(M)
+        @test A*A' ≈ one(A)
+        @test !isrotation(A)
     end
 
     @testset "Testing type aliases" begin

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -403,27 +403,30 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
     # Check that isrotation works
     #########################################################################
     @testset "Testing isrotation" begin
-      a=[1.0 0.0 0.0
-         0.0 0.0 -1.0
-         0.0 1.0 0.0]
-      @test isrotation(a)
-      foreach(rot_types) do rot_type
-        foreach(1:20) do idx
-          @test isrotation(rand(rot_type))
-        end
-      end
-      a=[40.0 0.0 0.0
-         0.0 0.0 1.0
-         0.0 1.0 0.0]
-      @test !isrotation(a)
-      a=[1.0 0.0 0.0
-         0.0 0.0 1.0
-         0.0 1.0 0.0]
-      @test !isrotation(a)
+        a=[1.0 0.0 0.0
+           0.0 0.0 -1.0
+           0.0 1.0 0.0]
+        @test isrotation(a)
 
-      # isrotation should work for integer (or boolean) matrices (issue #94)
-      @test isrotation([0 1 0; -1 0 0; 0 0 1])
-      @test isrotation(Matrix(I,3,3))
+        foreach(rot_types) do rot_type
+            foreach(1:20) do idx
+            @test isrotation(rand(rot_type))
+            end
+        end
+
+        a=[40.0 0.0 0.0
+           0.0 0.0 1.0
+           0.0 1.0 0.0]
+        @test !isrotation(a)
+
+        a=[1.0 0.0 0.0
+           0.0 0.0 1.0
+           0.0 1.0 0.0]
+        @test !isrotation(a)
+
+        # isrotation should work for integer (or boolean) matrices (issue #94)
+        @test isrotation([0 1 0; -1 0 0; 0 0 1])
+        @test isrotation(Matrix(I,3,3))
     end
 
     @testset "Testing type aliases" begin


### PR DESCRIPTION
This PR fixes #215.

* [x] `RotMatrix{N}` constructor
* [x] `RotMatrixGenerator{N}` constructor
* [x] `exp` function `RotMatrixGenerator{N}` to `RotMatrix{N}`
* [x] `log` function `RotMatrix{N}` to `RotMatrixGenerator{N}`
* [x] `isrotationgenerator` function
* [ ] ~`rotation_angle`~
* [x] `rand` method
* [x] documentation
