### PR TITLE
Drop support under Julia v1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 Quaternions = "0.4"
 StaticArrays = "0.10, 0.11, 0.12, 1.0"
-julia = "0.7, 1"
+julia = "1.6"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Quaternions = "0.4"
-StaticArrays = "1.0"
+StaticArrays = "1.2.12"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Quaternions = "0.4"
-StaticArrays = "0.10, 0.11, 0.12, 1.0"
+StaticArrays = "1.0"
 julia = "1.6"
 
 [extras]

--- a/test/2d.jl
+++ b/test/2d.jl
@@ -91,10 +91,8 @@ using Unitful
             for i = 1:repeats
                 r = rand(R)
                 @test norm(r) ≈ norm(Matrix(r))
-                if VERSION ≥ v"1.5"
-                    @test normalize(r) ≈ normalize(Matrix(r))
-                    @test normalize(r) isa SMatrix
-                end
+                @test normalize(r) ≈ normalize(Matrix(r))
+                @test normalize(r) isa SMatrix
             end
         end
     end

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -21,7 +21,7 @@
         @test norm(v3) ≈ 1
         @test E.values == λs
         @test E.vectors == vs
-        if !(T in oneaxis_types) && VERSION ≥ v"1.2"
+        if !(T in oneaxis_types)
             # If the rotation angle is in [0°, 180°], then the eigvals will be equal.
             # Note that the randomized RotX (and etc.) have rotation angle in [0°, 360°].
             # This needs Julia(≥1.2) to get sorted eigenvalues in a canonical order
@@ -46,12 +46,10 @@ end
         @test norm(v2) ≈ 1
         @test E.values == λs
         @test E.vectors == vs
-        if VERSION ≥ v"1.2"
-            # If the rotation angle θ is in [0°, 180°], then the eigvals will be equal.
-            # Note that the randomized RotX (and etc.) have rotation angle in [0°, 360°].
-            # This needs Julia(≥1.2) to get sorted eigenvalues in a canonical order
-            # See https://github.com/JuliaLang/julia/pull/21598
-            @test eigvals(R) ≈ eigvals(collect(R))
-        end
+        # If the rotation angle θ is in [0°, 180°], then the eigvals will be equal.
+        # Note that the randomized RotX (and etc.) have rotation angle in [0°, 360°].
+        # This needs Julia(≥1.2) to get sorted eigenvalues in a canonical order
+        # See https://github.com/JuliaLang/julia/pull/21598
+        @test eigvals(R) ≈ eigvals(collect(R))
     end
 end

--- a/test/rotation_generator.jl
+++ b/test/rotation_generator.jl
@@ -199,11 +199,7 @@
         r = zero(RotMatrixGenerator{2})
         show(io, MIME("text/plain"), r)
         str = String(take!(io))
-        if VERSION ≥ v"1.6"
-            @test startswith(str, "2×2 RotMatrixGenerator2{Float64}")
-        else
-            @test startswith(str, "2×2 RotMatrixGenerator{2,Float64,4}")
-        end
+        @test startswith(str, "2×2 RotMatrixGenerator2{Float64}")
 
         rvec = RotationVecGenerator(1.0, 2.0, 3.0)
         show(io, MIME("text/plain"), rvec)

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -163,10 +163,8 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
             for i = 1:repeats
                 r = rand(R)
                 @test norm(r) ≈ norm(Matrix(r))
-                if VERSION ≥ v"1.5"
-                    @test normalize(r) ≈ normalize(Matrix(r))
-                    @test normalize(r) isa SMatrix
-                end
+                @test normalize(r) ≈ normalize(Matrix(r))
+                @test normalize(r) isa SMatrix
             end
         end
     end
@@ -464,11 +462,7 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
         r = rand(RotMatrix{2})
         show(io, MIME("text/plain"), r)
         str = String(take!(io))
-        if VERSION ≥ v"1.6"
-            @test startswith(str, "2×2 RotMatrix2{Float64}")
-        else
-            @test startswith(str, "2×2 RotMatrix{2,Float64,4}")
-        end
+        @test startswith(str, "2×2 RotMatrix2{Float64}")
 
         rxyz = RotXYZ(1.0, 2.0, 3.0)
         show(io, MIME("text/plain"), rxyz)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,10 +8,6 @@ import Unitful
 
 import Random
 
-if VERSION < v"1.2.0"
-    Base.:<(x) = Base.Fix2(<, x)
-end
-
 # Check that there are no ambiguities beyond those present in StaticArrays
 ramb = detect_ambiguities(Rotations, Base, Core)
 samb = detect_ambiguities(StaticArrays, Base, Core)


### PR DESCRIPTION
As commented [here](https://github.com/JuliaGeometry/Rotations.jl/pull/219#issuecomment-1013818238), we can drop support versions of Julia lower than v1.6.