### PR TITLE
Fix around `RotMatrix2` and `RotMatrix3` aliases

### DIFF
--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -76,14 +76,6 @@ RotMatrix(x::SMatrix{N,N,T,L}) where {N,T,L} = RotMatrix{N,T,L}(x)
 
 Base.zero(::Type{RotMatrix}) = error("The dimension of rotation is not specified.")
 
-for N = 2:3
-    L = N*N
-    RotMatrixN = Symbol(:RotMatrix, N)
-    @eval begin
-        const $RotMatrixN{T} = RotMatrix{$N, T, $L}
-    end
-end
-
 # These functions (plus size) are enough to satisfy the entire StaticArrays interface:
 @inline function RotMatrix(t::NTuple{L}) where L
     n = sqrt(L)
@@ -97,11 +89,21 @@ end
 @inline RotMatrix{N,T}(t::NTuple) where {N,T} = RotMatrix(SMatrix{N,N,T}(t))
 @inline RotMatrix{N,T,L}(t::NTuple{L}) where {N,T,L} = RotMatrix(SMatrix{N,N,T}(t))
 
+# Create aliases RotMatrix2{T} = RotMatrix{2,T,4} and RotMatrix3{T} = RotMatrix{3,T,9}
+for N = 2:3
+    L = N*N
+    RotMatrixN = Symbol(:RotMatrix, N)
+    @eval begin
+        const $RotMatrixN{T} = RotMatrix{$N, T, $L}
+        @inline $RotMatrixN(t::NTuple{$L}) = RotMatrix(SMatrix{$N,$N}(t))
+    end
+end
+
 Base.@propagate_inbounds Base.getindex(r::RotMatrix, i::Int) = r.mat[i]
 @inline Base.Tuple(r::RotMatrix) = Tuple(r.mat)
 
 @inline RotMatrix(θ::Number) = RotMatrix{2}(θ)
-@inline function (::Type{RotMatrix{2}})(θ::Number)
+@inline function (::Type{<:RotMatrix{2}})(θ::Number)
     s, c = sincos(θ)
     RotMatrix(@SMatrix [c -s; s c])
 end

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -13,7 +13,7 @@ end
 # The unit sphere in R⁴ parameterizes quaternion rotations according to the
 # Haar measure of SO(3) - see e.g. http://math.stackexchange.com/questions/184086/uniform-distributions-on-the-space-of-rotations-in-3d
 function Random.rand(rng::AbstractRNG, ::Random.SamplerType{R}) where R <: Union{<:Rotation{3},<:RotMatrix{3}}
-    # We use the awkward Union{<:Rotation{2},<:RotMatrix{2}} here rather than `Rotation{2}`
+    # We use the awkward Union{<:Rotation{3},<:RotMatrix{3}} here rather than `Rotation{3}`
     # to make this efficient 3D method more specific than the method for general `RotMatrix`.
     T = eltype(R)
     if T == Any

--- a/test/distribution_tests.jl
+++ b/test/distribution_tests.jl
@@ -27,12 +27,12 @@ To visualize the distribution, try the following script.
 @testset "Distribution" begin
 
     # TODO: consider to remove Euler rotations (#155)
-    Type_SO3 =  (RotMatrix{3}, AngleAxis, RotationVec,
+    Type_SO3 =  (RotMatrix3, RotMatrix{3}, AngleAxis, RotationVec,
                 QuatRotation, MRP, RodriguesParam,
                 RotXYZ, RotYZX, RotZXY, RotXZY, RotYXZ, RotZYX,
                 RotXYX, RotYZY, RotZXZ, RotXZX, RotYXY, RotZYZ)
 
-    Type_SO2 = (RotMatrix{2}, Angle2d, RotX, RotY, RotZ)
+    Type_SO2 = (RotMatrix2, RotMatrix{2}, Angle2d, RotX, RotY, RotZ)
 
     # Number of sampling
     N = 100000

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -1,5 +1,5 @@
 @testset "Eigen_3D" begin
-    all_types = (RotMatrix{3}, AngleAxis, RotationVec,
+    all_types = (RotMatrix3, RotMatrix{3}, AngleAxis, RotationVec,
                  QuatRotation, RodriguesParam, MRP,
                  RotXYZ, RotYZX, RotZXY, RotXZY, RotYXZ, RotZYX,
                  RotXYX, RotYZY, RotZXZ, RotXZX, RotYXY, RotZYZ,
@@ -32,7 +32,7 @@
 end
 
 @testset "Eigen_2D" begin
-    all_types = (RotMatrix{2}, Angle2d)
+    all_types = (RotMatrix2, RotMatrix{2}, Angle2d)
 
     @testset "$(T)" for T in all_types, θ in 0.0:0.1:π
         R = T(Angle2d(θ))

--- a/test/logexp.jl
+++ b/test/logexp.jl
@@ -1,11 +1,11 @@
 @testset "log" begin
-    all_types = (RotMatrix{3}, AngleAxis, RotationVec,
+    all_types = (RotMatrix3, RotMatrix{3}, AngleAxis, RotationVec,
                  QuatRotation, RodriguesParam, MRP,
                  RotXYZ, RotYZX, RotZXY, RotXZY, RotYXZ, RotZYX,
                  RotXYX, RotYZY, RotZXZ, RotXZX, RotYXY, RotZYZ,
                  RotX, RotY, RotZ,
                  RotXY, RotYZ, RotZX, RotXZ, RotYX, RotZY,
-                 RotMatrix{2}, Angle2d)
+                 RotMatrix2, RotMatrix{2}, Angle2d)
 
     @testset "$(T)" for T in all_types, F in (one, rand)
         R = F(T)

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -65,7 +65,7 @@ end
 # build a full list of rotation types including the different angle ordering schemas
 #####################################################################################
 
-rot_types = (RotMatrix{3}, AngleAxis, RotationVec,
+rot_types = (RotMatrix3, RotMatrix{3}, AngleAxis, RotationVec,
              QuatRotation, RodriguesParam, MRP,
              RotXYZ, RotYZX, RotZXY, RotXZY, RotYXZ, RotZYX,
              RotXYX, RotYZY, RotZXZ, RotXZX, RotYXY, RotZYZ)
@@ -73,7 +73,7 @@ rot_types = (RotMatrix{3}, AngleAxis, RotationVec,
 one_types = (RotX, RotY, RotZ)
 two_types = (RotXY, RotYZ, RotZX, RotXZ, RotYX, RotZY)
 taitbyran_types = (RotXYZ, RotYZX, RotZXY, RotXZY, RotYXZ, RotZYX)
-all_types = (RotMatrix{3}, AngleAxis, RotationVec,
+all_types = (RotMatrix3, RotMatrix{3}, AngleAxis, RotationVec,
              QuatRotation, RodriguesParam, MRP,
              RotXYZ, RotYZX, RotZXY, RotXZY, RotYXZ, RotZYX,
              RotXYX, RotYZY, RotZXZ, RotXZX, RotYXY, RotZYZ,
@@ -86,7 +86,8 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
 
 @testset "Rotations Tests" begin
     # Ensure we're testing all 3D rotation types
-    @test length(all_types) == length(setdiff(subtypes(Rotation), [Angle2d]))
+    @test setdiff(subtypes(Rotation), all_types) == [Angle2d, RotMatrix]
+    @test setdiff(all_types, subtypes(Rotation)) == [RotMatrix3, RotMatrix{3}]
 
     ###############################
     # Check fixed relationships


### PR DESCRIPTION
This PR fixes #205

**Before this PR**
```julia
julia> rand(RotMatrix{3})
3×3 RotMatrix3{Float64} with indices SOneTo(3)×SOneTo(3):
 -0.203707   0.62082    0.757025
 -0.258638   0.711643  -0.6532
 -0.944251  -0.328857   0.015601

julia> rand(RotMatrix{2})
2×2 RotMatrix2{Float64} with indices SOneTo(2)×SOneTo(2):
  0.701313  0.712853
 -0.712853  0.701313

julia> rand(RotMatrix3{Float64})
3×3 RotMatrix3{Float64} with indices SOneTo(3)×SOneTo(3):
 0.310501  -0.483375  -0.818497
 0.373853   0.853765  -0.36238
 0.87397   -0.193479   0.445806

julia> rand(RotMatrix2{Float64})
ERROR: DimensionMismatch("No precise constructor for RotMatrix2{Float64} found. Length of input was 1.")
Stacktrace:
 [1] RotMatrix2{Float64}(x::Tuple{Tuple{Tuple{Tuple{Float64}}}})
   @ StaticArrays ~/.julia/dev/StaticArrays/src/convert.jl:1
 [2] StaticArray (repeats 4 times)
   @ ~/.julia/dev/StaticArrays/src/convert.jl:4 [inlined]
 [3] rand(rng::Random.MersenneTwister, #unused#::Random.SamplerType{RotMatrix2{Float64}})
   @ Rotations ~/.julia/dev/Rotations/src/core_types.jl:49
 [4] rand(rng::Random.MersenneTwister, ::Type{RotMatrix2{Float64}})
   @ Random /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Random/src/Random.jl:256
 [5] rand(#unused#::Type{RotMatrix2{Float64}})
   @ Random /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Random/src/Random.jl:259
 [6] top-level scope
   @ REPL[11]:1

julia> rand(RotMatrix3)
ERROR: DimensionMismatch("No precise constructor for RotMatrix3{T} where T found. Length of input was 9.")
Stacktrace:
 [1] (RotMatrix3{T} where T)(x::Tuple{Tuple{Tuple{NTuple{9, Float64}}}})
   @ StaticArrays ~/.julia/dev/StaticArrays/src/convert.jl:1
 [2] (RotMatrix3{T} where T)(x::Tuple{Tuple{NTuple{9, Float64}}}) (repeats 3 times)
   @ StaticArrays ~/.julia/dev/StaticArrays/src/convert.jl:4
 [3] StaticArray
   @ ~/.julia/dev/StaticArrays/src/convert.jl:5 [inlined]
 [4] rand(rng::Random.MersenneTwister, #unused#::Random.SamplerType{RotMatrix3{T} where T})
   @ Rotations ~/.julia/dev/Rotations/src/core_types.jl:62
 [5] rand(rng::Random.MersenneTwister, ::Type{RotMatrix3{T} where T})
   @ Random /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Random/src/Random.jl:256
 [6] rand(#unused#::Type{RotMatrix3{T} where T})
   @ Random /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Random/src/Random.jl:259
 [7] top-level scope
   @ REPL[12]:1

julia> rand(RotMatrix2)
```

**After this PR**
```julia
julia> rand(RotMatrix{3})
3×3 RotMatrix3{Float64} with indices SOneTo(3)×SOneTo(3):
 -0.925821   0.00610591  -0.377913
 -0.153636  -0.919618     0.361522
 -0.345328   0.392766     0.85234

julia> rand(RotMatrix{2})
2×2 RotMatrix2{Float64} with indices SOneTo(2)×SOneTo(2):
 -0.484416   0.874838
 -0.874838  -0.484416

julia> rand(RotMatrix3{Float64})
3×3 RotMatrix3{Float64} with indices SOneTo(3)×SOneTo(3):
  0.075244   0.996148   0.0450262
 -0.127575  -0.0351664  0.991205
  0.988971  -0.0803265  0.124438

julia> rand(RotMatrix2{Float64})
2×2 RotMatrix2{Float64} with indices SOneTo(2)×SOneTo(2):
 0.91609   -0.400973
 0.400973   0.91609

julia> rand(RotMatrix3)
3×3 RotMatrix3{Float64} with indices SOneTo(3)×SOneTo(3):
 0.68451   -0.714964  -0.142381
 0.378025   0.515116  -0.769255
 0.623332   0.472739   0.622876

julia> rand(RotMatrix2)
2×2 RotMatrix2{Float64} with indices SOneTo(2)×SOneTo(2):
  0.99917    0.0407415
 -0.0407415  0.99917
```