### PR TITLE
Fix `Angle2d` constructor

### DIFF
--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -152,6 +152,7 @@ params(r::Angle2d) = SVector{1}(r.theta)
 
 Angle2d(r::Rotation{2}) = Angle2d(rotation_angle(r))
 Angle2d{T}(r::Rotation{2}) where {T} = Angle2d{T}(rotation_angle(r))
+@inline (::Type{R})(t::NTuple{4}) where R<:Angle2d = convert(R, RotMatrix(t))
 
 Base.one(::Type{A}) where {A<: Angle2d} = A(0)
 

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -141,10 +141,10 @@ of `getindex` etc. are computed on the fly.
 """
 struct Angle2d{T} <: Rotation{2,T}
     theta::T
-    Angle2d{T}(theta) where T = new{T}(theta)
+    Angle2d{T}(theta::Number) where T = new{T}(theta)
 end
 
-@inline function Angle2d(theta)
+@inline function Angle2d(theta::Number)
     Angle2d{rot_eltype(typeof(theta))}(theta)
 end
 

--- a/test/2d.jl
+++ b/test/2d.jl
@@ -8,9 +8,14 @@ using Unitful
     #################################
 
     @testset "Core" begin
-        r = one(RotMatrix{2,Float32})
-        @test RotMatrix((1,0,0,1)) == RotMatrix(@SMatrix [1 0; 0 1])
+        @test RotMatrix((1,0,0,1)) == RotMatrix(@SMatrix [1 0;0 1]) == one(SMatrix{2,2})
+        @test Angle2d((1,0,0,1))   == RotMatrix(@SMatrix [1 0;0 1]) == one(SMatrix{2,2})
+        @test RotMatrix((1,0,0,1)) isa RotMatrix2{Int}
+        @test Angle2d((1,0,0,1))   isa Angle2d{Float64}
+        @test RotMatrix{2,Float32}((1,0,0,1)) isa RotMatrix2{Float32}
+        @test Angle2d{Float32}((1,0,0,1))   isa Angle2d{Float32}
         @test_throws DimensionMismatch RotMatrix((1,0,0,1,0))
+        @test_throws DimensionMismatch Angle2d((1,0,0,1,0))
     end
 
     @testset "Unitful" begin


### PR DESCRIPTION
This PR fixes #212.

**Before this PR**
```julia
julia> using Rotations, StaticArrays

julia> Angle2d((1,0,0,1))
ERROR: MethodError: no method matching zero(::Type{NTuple{4, Int64}})
Closest candidates are:
  zero(::Union{Type{P}, P}) where P<:Dates.Period at ~/julia/julia-1.7.1/share/julia/stdlib/v1.7/Dates/src/periods.jl:53
  zero(::AbstractIrrational) at ~/julia/julia-1.7.1/share/julia/base/irrationals.jl:150
  zero(::LinearAlgebra.Diagonal{T, SVector{N, T}}) where {N, T} at ~/.julia/dev/StaticArrays/src/SDiagonal.jl:41
  ...
Stacktrace:
 [1] rot_eltype(angle_type::Type)
   @ Rotations ~/.julia/dev/Rotations/src/util.jl:49
 [2] Angle2d(theta::NTuple{4, Int64})
   @ Rotations ~/.julia/dev/Rotations/src/core_types.jl:148
 [3] top-level scope
   @ REPL[4]:1

julia> Angle2d(one(SMatrix{2,2}))
ERROR: MethodError: Angle2d(::SMatrix{2, 2, Float64, 4}) is ambiguous. Candidates:
  (::Type{SA})(a::StaticArray) where SA<:StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:5
  (::Type{SA})(a::AbstractArray) where SA<:StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:7
  Angle2d(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/core_types.jl:147
Possible fix, define
  Angle2d(::StaticArray)
Stacktrace:
 [1] top-level scope
   @ REPL[5]:1

julia> Angle2d(rand(2,2))
ERROR: MethodError: Angle2d(::Matrix{Float64}) is ambiguous. Candidates:
  (::Type{SA})(a::AbstractArray) where SA<:StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:7
  Angle2d(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/core_types.jl:147
Possible fix, define
  Angle2d(::AbstractArray)
Stacktrace:
 [1] top-level scope
   @ REPL[6]:1
```

**After this PR**
```julia
julia> using Rotations, StaticArrays

julia> Angle2d((1,0,0,1))
2×2 Angle2d{Float64} with indices SOneTo(2)×SOneTo(2)(0.0):
 1.0  -0.0
 0.0   1.0

julia> Angle2d(one(SMatrix{2,2}))
2×2 Angle2d{Float64} with indices SOneTo(2)×SOneTo(2)(0.0):
 1.0  -0.0
 0.0   1.0

2×2 Angle2d{Float64} with indices SOneTo(2)×SOneTo(2)(0.896298):
 0.624506  -0.78102
 0.78102    0.624506
```
