### PR TITLE
Bump compat for Quaternions to 0.4.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Quaternions = "0.4"
+Quaternions = "0.4.5"
 StaticArrays = "1.2.12"
 julia = "1.6"
 


### PR DESCRIPTION
This PR prevents a type piracy bug in pre 0.4.5 Quaternions from leaking through.

See https://github.com/JuliaGeometry/Quaternions.jl/pull/53

### Before this PR when Quaternions@0.4.4 was installed.

```julia
julia> using LinearAlgebra

julia> normalize(zeros(3))
3-element Vector{Float64}:
 NaN
 NaN
 NaN

julia> using Rotations

julia> normalize(zeros(3))
3-element Vector{Float64}:
 0.0
 0.0
 0.0
```

### After this PR when Quaternions@0.4.5 was installed.

```julia
julia> using LinearAlgebra

julia> normalize(zeros(3))
3-element Vector{Float64}:
 NaN
 NaN
 NaN
 
julia> using Rotations

julia> normalize(zeros(3))
3-element Vector{Float64}:
 NaN
 NaN
 NaN
```