### PR TITLE
Bump version to `v1.3.0`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Rotations"
 uuid = "6038ab10-8711-5258-84ad-4b1120ba62dc"
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
After merging #224, I'd like to release `v1.3.0`.

#220 drops support under Julia v1.6, and #220 adds a new feature (adding support for higher dimensional rotation). So, the next release will update the minor version. Other improvements are bug fixes etc.