### PR TITLE
Cleanup around `Quaternion`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Quaternions = "0.4.5, 0.5"
+Quaternions = "0.5.3"
 StaticArrays = "1.2.12"
 julia = "1.6"
 

--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -78,10 +78,8 @@ end
 end
 
 @inline function (::Type{AA})(q::QuatRotation) where AA <: AngleAxis
-    w = q.q.s
-    x = q.q.v1
-    y = q.q.v2
-    z = q.q.v3
+    w = real(q.q)
+    x, y, z = imag_part(q.q)
     s2 = x * x + y * y + z * z
     sin_t2 = sqrt(s2)
     theta = 2 * atan(sin_t2, w)

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -31,10 +31,8 @@ to the output parameterization, centered at the value of R.
 Returns the jacobian for rotating the vector X by R.
 """
 function jacobian(::Type{RotMatrix},  q::QuatRotation)
-    w = q.q.s
-    x = q.q.v1
-    y = q.q.v2
-    z = q.q.v3
+    w = real(q.q)
+    x, y, z = imag_part(q.q)
 
     # let q = s * qhat where qhat is a unit quaternion and  s is a scalar,
     # then R = RotMatrix(q) = RotMatrix(s * qhat) = s * RotMatrix(qhat)
@@ -138,10 +136,8 @@ end
 # Jacobian converting from a Quaternion to an MRP
 #
 function jacobian(::Type{MRP}, q::QuatRotation{T}) where T
-    w = q.q.s
-    x = q.q.v1
-    y = q.q.v2
-    z = q.q.v3
+    w = real(q.q)
+    x, y, z = imag_part(q.q)
 
     den = 1 + w
     scale = 1 / den
@@ -184,10 +180,8 @@ end
 
 # TODO: should this be jacobian(:rotate, q,  X)   # or something?
 function jacobian(q::QuatRotation, X::AbstractVector)
-    w = q.q.s
-    x = q.q.v1
-    y = q.q.v2
-    z = q.q.v3
+    w = real(q.q)
+    x, y, z = imag_part(q.q)
 
     @assert length(X) === 3
     T = eltype(q)

--- a/src/error_maps.jl
+++ b/src/error_maps.jl
@@ -220,10 +220,8 @@ end
 
 
 function jacobian(::InvCayleyMap, q::QuatRotation)
-    w = q.q.s
-    x = q.q.v1
-    y = q.q.v2
-    z = q.q.v3
+    w = real(q.q)
+    x, y, z = imag_part(q.q)
 
     μ = scaling(CayleyMap)
     si = 1/w
@@ -234,10 +232,8 @@ end
 
 
 function jacobian(::InvMRPMap, q::QuatRotation)
-    w = q.q.s
-    x = q.q.v1
-    y = q.q.v2
-    z = q.q.v3
+    w = real(q.q)
+    x, y, z = imag_part(q.q)
 
     μ = scaling(MRPMap)
     si = 1/(1+w)

--- a/src/mrps.jl
+++ b/src/mrps.jl
@@ -35,10 +35,8 @@ Base.one(::Type{RP}) where RP <: MRP = RP(0.0, 0.0, 0.0)
 end
 
 @inline function (::Type{RP})(q::QuatRotation) where RP<:MRP
-    w = q.q.s
-    x = q.q.v1
-    y = q.q.v2
-    z = q.q.v3
+    w = real(q.q)
+    x, y, z = imag_part(q.q)
 
     M = 1/(1+w)
     RP(x*M, y*M, z*M)

--- a/src/rodrigues_params.jl
+++ b/src/rodrigues_params.jl
@@ -32,10 +32,8 @@ params(g::RodriguesParam) = SVector{3}(g.x, g.y, g.z)
 end
 
 @inline function (::Type{G})(q::QuatRotation) where G<:RodriguesParam
-    w = q.q.s
-    x = q.q.v1
-    y = q.q.v2
-    z = q.q.v3
+    w = real(q.q)
+    x, y, z = imag_part(q.q)
 
     return G(x/w, y/w, z/w)
 end

--- a/test/rodrigues_params.jl
+++ b/test/rodrigues_params.jl
@@ -68,7 +68,7 @@ end
     @test ω ≈ 2*vmat()*lmult(q)'qdot
     @test ω ≈ 2*vmat()*lmult(inv(q))*qdot
     q2 = Quaternion(q)*pure_quaternion(ω)
-    @test qdot ≈ SVector(q2.s, q2.v1, q2.v2, q2.v3)/2
+    @test qdot ≈ SVector(real(q2), imag_part(q2)...)/2
 
     # MRPs
     ω = @SVector rand(3)

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -205,7 +205,7 @@ all_types = (RotMatrix3, RotMatrix{3}, AngleAxis, RotationVec,
             @test Rotations.params(q2) ≈ -Rotations.params(q) atol = 100 * eps()
             @test q ≈ q2 atol = 100 * eps()
 
-            q3 = QuatRotation(-q.q.s, -q.q.v1, -q.q.v2, -q.q.v3, false) # don't normalize: everything is exact
+            q3 = QuatRotation(-real(q.q), (-).imag_part(q.q)..., false) # don't normalize: everything is exact
             @test Rotations.params(q3) == -Rotations.params(q)
             @test q == q3
 


### PR DESCRIPTION
`Quaternions.imag_part` was introduced in https://github.com/JuliaGeometry/Quaternions.jl/pull/77.
This PR cleans up scripts with the funciton.