### PR TITLE
Fix `real(::Type{<:Rotation})`

### DIFF
--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -11,6 +11,7 @@ Base.@pure StaticArrays.Size(::Type{Rotation{N,T}}) where {N,T} = Size(N,N)
 Base.@pure StaticArrays.Size(::Type{R}) where {R<:Rotation} = Size(supertype(R))
 Base.adjoint(r::Rotation) = inv(r)
 Base.transpose(r::Rotation{N,T}) where {N,T<:Real} = inv(r)
+Base.real(R::Type{<:Rotation}) = R
 
 # Generate zero-matrix with SMatrix
 # Note that zeros(Rotation3,dims...) is not Array{<:Rotation} but Array{<:StaticMatrix{3,3}}

--- a/src/rotation_generator.jl
+++ b/src/rotation_generator.jl
@@ -11,6 +11,7 @@ Base.@pure StaticArrays.Size(::Type{RotationGenerator{N,T}}) where {N,T} = Size(
 Base.@pure StaticArrays.Size(::Type{R}) where {R<:RotationGenerator} = Size(supertype(R))
 Base.adjoint(r::RotationGenerator) = -r
 Base.transpose(r::RotationGenerator{N,T}) where {N,T<:Real} = -r
+Base.real(R::Type{<:RotationGenerator}) = R
 
 # Generate identity-matrix with SMatrix
 # Note that ones(RotationGenerator3,dims...) is not Array{<:RotationGenerator} but Array{<:StaticMatrix{3,3}}

--- a/test/rotation_generator.jl
+++ b/test/rotation_generator.jl
@@ -73,6 +73,15 @@
         @test one(RotationGenerator{3,BigFloat}) isa SMatrix{3, 3, BigFloat}
     end
 
+    @testset "real" begin
+        @testset "$(R)" for R in all_types
+            @test real(R) === R
+            @test real(one(R)) === one(R)
+        end
+        @test real(RotationGenerator) === RotationGenerator
+        @test real(RotMatrixGenerator) === RotMatrixGenerator
+    end
+
     @testset "minus" begin
         for T in all_types
             # TODO: These should be replaced with `r = rand(T)`

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -128,6 +128,19 @@ all_types = (RotMatrix3, RotMatrix{3}, AngleAxis, RotationVec,
         @test_throws ErrorException zero(RotMatrix)
     end
 
+    ###############################
+    # Check real function
+    ###############################
+
+    @testset "real checks" begin
+        @testset "$(R)" for R in all_types
+            @test real(R) === R
+            @test real(one(R)) === one(R)
+        end
+        @test real(Rotation) === Rotation
+        @test real(RotMatrix) === RotMatrix
+    end
+
     ################################
     # check on the inverse function
     ################################


### PR DESCRIPTION
This PR partially resolves #185.

```julia
julia> using Rotations

julia> real(RotX)
RotX

julia> real(QuatRotation)
QuatRotation

julia> real(QuatRotation{Float32})
QuatRotation{Float32}

julia> float(QuatRotation{Int})  # this should be QuatRotation{Float64}, but this will be fixed in other PR.
SMatrix{3, 3, Float64, 9} (alias for StaticArrays.SArray{Tuple{3, 3}, Float64, 2, 9})
```