### PR TITLE
remove some ambiguities

### DIFF
--- a/src/euler_types.jl
+++ b/src/euler_types.jl
@@ -14,11 +14,11 @@ for axis in [:X, :Y, :Z]
     @eval begin
         struct $RotType{T} <: Rotation{3,T}
             theta::T
-            $RotType{T}(theta) where {T} = new{T}(theta)
+            $RotType{T}(theta::Number) where {T} = new{T}(theta)
             $RotType{T}(r::$RotType) where {T} = new{T}(r.theta)
         end
 
-        @inline function $RotType(theta)
+        @inline function $RotType(theta::Number)
             $RotType{rot_eltype(typeof(theta))}(theta)
         end
         @inline $RotType(r::$RotType{T}) where {T} = $RotType{T}(r)

--- a/src/rotation_generator.jl
+++ b/src/rotation_generator.jl
@@ -22,6 +22,7 @@ Base.one(::Type{<:RotationGenerator{N,T}}) where {N,T} = one(SMatrix{N,N,T})
 Base.ones(::Type{R}) where {R<:RotationGenerator} = ones(R, ()) # avoid StaticArray constructor
 Base.ones(::Type{R}, dims::Base.DimOrInd...) where {R<:RotationGenerator} = ones(typeof(one(R)),dims...)
 Base.ones(::Type{R}, dims::NTuple{N, Integer}) where {R<:RotationGenerator, N} = ones(typeof(one(R)),dims)
+Base.ones(::Type{R}, dims::Tuple{}) where {R<:RotationGenerator} = ones(typeof(one(R)),dims)
 
 # Generate zero rotation matrix
 Base.zero(r::RotationGenerator) = zero(typeof(r))
@@ -124,7 +125,7 @@ A 2×2 rotation generator matrix (i.e. skew-symmetric matrix).
 """
 struct Angle2dGenerator{T} <: RotationGenerator{2,T}
     v::T
-    Angle2dGenerator{T}(r) where T = new{T}(r)
+    Angle2dGenerator{T}(r::Number) where T = new{T}(r)
 end
 
 @inline function Angle2dGenerator(r::T) where T <: Number

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -74,8 +74,9 @@ end
     check_length(q, 4)
     Q(q[1], q[2], q[3], q[4], normalize)
 end
-@inline (::Type{Q})(q::StaticVector{4}, normalize::Bool = true) where Q <: QuatRotation =
+@inline function (::Type{Q})(q::StaticVector{4}, normalize::Bool = true) where Q <: QuatRotation
     Q(q[1], q[2], q[3], q[4], normalize)
+end
 
 # Copy constructors
 QuatRotation(q::QuatRotation) = q

--- a/test/rotation_generator.jl
+++ b/test/rotation_generator.jl
@@ -51,6 +51,7 @@
             r = one(T)
             @test r isa SMatrix
             @test r == one(r)
+            @test ones(T,()) isa Array{typeof(one(T)), 0}
             @test ones(T,2,3) == [one(T) for i in 1:2, j in 1:3]
             @test ones(T{BigFloat},2,3) == [one(T{BigFloat}) for i in 1:2, j in 1:3]
             @test ones(T,(2,3)) == [one(T) for i in 1:2, j in 1:3]


### PR DESCRIPTION
**Before this PR**
```julia
julia> using Rotations, Test

julia> detect_ambiguities(Rotations)
37-element Vector{Tuple{Method, Method}}:
 (RotY{T}(theta) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:17, (::Type{SA})(gen::Base.Generator) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/SArray.jl:54)
 (RotX{T}(theta) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:17, (::Type{SA})(gen::Base.Generator) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/SArray.jl:54)
 (Angle2dGenerator{T}(r) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/rotation_generator.jl:127, (::Type{SA})(sa::StaticArraysCore.StaticArray) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:165)
 (RotX(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:21, (::Type{SA})(sa::StaticArraysCore.StaticArray) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:165)
 (RotZ(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:21, (::Type{SA})(gen::Base.Generator) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/SArray.jl:54)
 (Angle2dGenerator{T}(r) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/rotation_generator.jl:127, (::Type{SA})(gen::Base.Generator) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/SArray.jl:54)
 (RotX(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:21, (::Type{SA})(a::AbstractArray) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:169)
 (RotZ(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:21, (::Type{SA})(sa::StaticArraysCore.StaticArray) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:165)
 ((::Type{Q})(q::AbstractVector) where Q<:QuatRotation in Rotations at /home/hyrodium/.julia/dev/Rotations/src/unitquaternion.jl:73, (::Type{SA})(sa::StaticArraysCore.StaticArray) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:165)
 (RotZ{T}(theta) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:17, (::Type{SA})(gen::Base.Generator) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/SArray.jl:54)
 (RotY{T}(theta) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:17, (::Type{SA})(a::AbstractArray) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:169)
 (RotY(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:21, (::Type{SA})(a::AbstractArray) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:169)
 (RotY{T}(theta) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:17, (::Type{SA})(sa::StaticArraysCore.StaticArray) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:165)
 (RotX{T}(theta) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:17, (::Type{SA})(sa::StaticArraysCore.StaticArray) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:165)
 (RotX{T}(theta) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:17, (::Type{SA})(a::AbstractArray) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:169)
 (RotY{T}(theta) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:17, (::Type{SM})(I::LinearAlgebra.UniformScaling) where SM<:(StaticArraysCore.StaticArray{Tuple{N, M}, T, 2} where {N, M, T}) in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/linalg.jl:126)
 (RotX{T}(theta) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:17, (::Type{SM})(I::LinearAlgebra.UniformScaling) where SM<:(StaticArraysCore.StaticArray{Tuple{N, M}, T, 2} where {N, M, T}) in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/linalg.jl:126)
 (RotY(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:21, (::Type{SA})(gen::Base.Generator) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/SArray.jl:54)
 (RotY{T}(theta) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:17, (::Type{SM})(I::LinearAlgebra.UniformScaling) where SM<:(StaticArraysCore.StaticArray{Tuple{N, M}} where {N, M}) in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/linalg.jl:130)
 (RotZ(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:21, (::Type{SA})(a::AbstractArray) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:169)
 (RotX(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:21, (::Type{SM})(I::LinearAlgebra.UniformScaling) where SM<:(StaticArraysCore.StaticArray{Tuple{N, M}} where {N, M}) in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/linalg.jl:130)
 (RotZ(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:21, (::Type{SM})(I::LinearAlgebra.UniformScaling) where SM<:(StaticArraysCore.StaticArray{Tuple{N, M}} where {N, M}) in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/linalg.jl:130)
 (Angle2dGenerator{T}(r) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/rotation_generator.jl:127, (::Type{SM})(I::LinearAlgebra.UniformScaling) where SM<:(StaticArraysCore.StaticArray{Tuple{N, M}, T, 2} where {N, M, T}) in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/linalg.jl:126)
 (RotZ{T}(theta) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:17, (::Type{SM})(I::LinearAlgebra.UniformScaling) where SM<:(StaticArraysCore.StaticArray{Tuple{N, M}, T, 2} where {N, M, T}) in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/linalg.jl:126)
 (RotZ{T}(theta) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:17, (::Type{SM})(I::LinearAlgebra.UniformScaling) where SM<:(StaticArraysCore.StaticArray{Tuple{N, M}} where {N, M}) in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/linalg.jl:130)
 (RotX(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:21, (::Type{SM})(I::LinearAlgebra.UniformScaling) where SM<:(StaticArraysCore.StaticArray{Tuple{N, M}, T, 2} where {N, M, T}) in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/linalg.jl:126)
 (RotY(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:21, (::Type{SM})(I::LinearAlgebra.UniformScaling) where SM<:(StaticArraysCore.StaticArray{Tuple{N, M}, T, 2} where {N, M, T}) in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/linalg.jl:126)
 (ones(::Type{R}, dims::Tuple{Vararg{Integer, N}}) where {R<:RotationGenerator, N} in Rotations at /home/hyrodium/.julia/dev/Rotations/src/rotation_generator.jl:24, ones(::Type{T}, dims::Tuple{}) where T in Base at array.jl:529)
 (RotZ(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:21, (::Type{SM})(I::LinearAlgebra.UniformScaling) where SM<:(StaticArraysCore.StaticArray{Tuple{N, M}, T, 2} where {N, M, T}) in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/linalg.jl:126)
 (Angle2dGenerator{T}(r) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/rotation_generator.jl:127, (::Type{SA})(a::AbstractArray) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:169)
 (RotY(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:21, (::Type{SA})(sa::StaticArraysCore.StaticArray) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:165)
 (RotX(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:21, (::Type{SA})(gen::Base.Generator) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/SArray.jl:54)
 (RotY(theta) in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:21, (::Type{SM})(I::LinearAlgebra.UniformScaling) where SM<:(StaticArraysCore.StaticArray{Tuple{N, M}} where {N, M}) in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/linalg.jl:130)
 (RotZ{T}(theta) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:17, (::Type{SA})(sa::StaticArraysCore.StaticArray) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:165)
 (Angle2dGenerator{T}(r) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/rotation_generator.jl:127, (::Type{SM})(I::LinearAlgebra.UniformScaling) where SM<:(StaticArraysCore.StaticArray{Tuple{N, M}} where {N, M}) in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/linalg.jl:130)
 (RotX{T}(theta) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:17, (::Type{SM})(I::LinearAlgebra.UniformScaling) where SM<:(StaticArraysCore.StaticArray{Tuple{N, M}} where {N, M}) in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/linalg.jl:130)
 (RotZ{T}(theta) where T in Rotations at /home/hyrodium/.julia/dev/Rotations/src/euler_types.jl:17, (::Type{SA})(a::AbstractArray) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:169)

```


**After this PR**
```julia
julia> using Rotations, Test

julia> detect_ambiguities(Rotations)
1-element Vector{Tuple{Method, Method}}:
 ((::Type{Q})(q::AbstractVector) where Q<:QuatRotation in Rotations at /home/hyrodium/.julia/dev/Rotations/src/unitquaternion.jl:73, (::Type{SA})(sa::StaticArraysCore.StaticArray) where SA<:StaticArraysCore.StaticArray in StaticArrays at /home/hyrodium/.julia/dev/StaticArrays/src/convert.jl:165)
```
