### PR TITLE
Remove `norm` field in `Quaternion`

### DIFF
--- a/src/rand.jl
+++ b/src/rand.jl
@@ -66,5 +66,6 @@ end
 end
 
 function Random.rand(rng::AbstractRNG, ::Random.SamplerType{<:QuatRotation{T}}) where T
-    _normalize(QuatRotation{T}(randn(rng,T), randn(rng,T), randn(rng,T), randn(rng,T)))
+    q = Quaternion(randn(rng,T), randn(rng,T), randn(rng,T), randn(rng,T))
+    return QuatRotation{T}(sign(q))
 end

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -20,17 +20,17 @@ struct QuatRotation{T} <: Rotation{3,T}
     @inline function QuatRotation{T}(w, x, y, z, normalize::Bool = true) where T
         if normalize
             inorm = inv(sqrt(w*w + x*x + y*y + z*z))
-            new{T}(Quaternion(w*inorm, x*inorm, y*inorm, z*inorm, true))
+            new{T}(Quaternion(w*inorm, x*inorm, y*inorm, z*inorm))
         else
-            new{T}(Quaternion(w, x, y, z, true))
+            new{T}(Quaternion(w, x, y, z))
         end
     end
 
-    @inline function QuatRotation{T}(q::Quaternion) where T
-        if q.norm
-            new{T}(q)
+    @inline function QuatRotation{T}(q::Quaternion, normalize::Bool = true) where T
+        if normalize
+            new{T}(sign(q))
         else
-            throw(InexactError(nameof(T), T, q))
+            new{T}(q)
         end
     end
     QuatRotation{T}(q::QuatRotation) where T = new{T}(q.q)
@@ -57,11 +57,11 @@ function QuatRotation(w,x,y,z, normalize::Bool = true)
     QuatRotation{eltype(types)}(w,x,y,z, normalize)
 end
 
-function QuatRotation(q::T) where T<:Quaternion
-    if q.norm
-        return QuatRotation(real(q), imag_part(q)..., false)
+function QuatRotation(q::Quaternion{T}, normalize::Bool = true) where T<:Real
+    if normalize
+        return QuatRotation{float(T)}(sign(q))
     else
-        throw(InexactError(nameof(T), T, q))
+        return QuatRotation{float(T)}(q)
     end
 end
 

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -231,14 +231,6 @@ Rotations.params(p) == @SVector [1.0, 2.0, 3.0]  # true
 # Inverses
 Base.inv(q::Q) where Q <: QuatRotation = Q(conj(q.q), false)
 
-function _normalize(q::Q) where Q <: QuatRotation
-    w = real(q.q)
-    x, y, z = imag_part(q.q)
-
-    n = norm(params(q))
-    Q(w/n, x/n, y/n, z/n)
-end
-
 # Identity
 (::Type{Q})(I::UniformScaling) where Q <: QuatRotation = one(Q)
 

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -223,13 +223,13 @@ Rotations.params(p) == @SVector [1.0, 2.0, 3.0]  # true
 @inline params(q::QuatRotation) = SVector{4}(real(q.q), imag_part(q.q)...)
 
 # ~~~~~~~~~~~~~~~ Initializers ~~~~~~~~~~~~~~~ #
-@inline Base.one(::Type{Q}) where Q <: QuatRotation = Q(1.0, 0.0, 0.0, 0.0)
+@inline Base.one(::Type{Q}) where Q <: QuatRotation = Q(1.0, 0.0, 0.0, 0.0, false)
 
 
 # ~~~~~~~~~~~~~~~ Math Operations ~~~~~~~~~~~~~~~ #
 
 # Inverses
-Base.inv(q::Q) where Q <: QuatRotation = Q(conj(q.q))
+Base.inv(q::Q) where Q <: QuatRotation = Q(conj(q.q), false)
 
 function _normalize(q::Q) where Q <: QuatRotation
     w = real(q.q)
@@ -299,7 +299,7 @@ rmult(w) * SVector(q)
 Sets the output mapping equal to the mapping of `w`
 """
 function Base.:*(q1::QuatRotation, q2::QuatRotation)
-    return QuatRotation(q1.q*q2.q)
+    return QuatRotation(q1.q * q2.q, false)
 end
 
 """

--- a/test/unitquat.jl
+++ b/test/unitquat.jl
@@ -14,7 +14,7 @@ import Rotations: vmat, rmult, lmult, hmat, tmat
     @test QuatRotation(1.0, 0.0, 0.0, 0.0) isa QuatRotation{Float64}
     @test QuatRotation(1.0, 0, 0, 0) isa QuatRotation{Float64}
     @test QuatRotation(1.0, 0, 0, 0) isa QuatRotation{Float64}
-    @test QuatRotation(1, 0, 0, 0) isa QuatRotation{Int}
+    @test QuatRotation(1, 0, 0, 0) isa QuatRotation{Float64}
     @test QuatRotation(1.0f0, 0, 0, 0) isa QuatRotation{Float32}
 
     q = normalize(@SVector rand(4))


### PR DESCRIPTION
The `norm` field was deprecated in https://github.com/JuliaGeometry/Quaternions.jl/pull/110, and will be removed in https://github.com/JuliaGeometry/Quaternions.jl/pull/108. This PR removes the `norm` field in `Quaternion`.