### PR TITLE
`rotation_between` for general dimensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Rotations"
 uuid = "6038ab10-8711-5258-84ad-4b1120ba62dc"
-version = "1.4.0"
+version = "1.5.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/Rotations.jl
+++ b/src/Rotations.jl
@@ -26,6 +26,7 @@ include("rotation_generator.jl")
 include("logexp.jl")
 include("eigen.jl")
 include("rand.jl")
+include("rotation_between.jl")
 include("deprecated.jl")
 
 export

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,2 +1,4 @@
 # Deprecate UnitQuaternion => QuatRotation
 Base.@deprecate_binding UnitQuaternion QuatRotation true
+
+Base.@deprecate rotation_between(from::AbstractVector, to::AbstractVector) rotation_between(SVector{3}(from), SVector{3}(to))

--- a/src/rotation_between.jl
+++ b/src/rotation_between.jl
@@ -24,15 +24,15 @@ end
 
 function rotation_between(u::SVector{N}, v::SVector{N}) where N
     e1 = normalize(u)
-    e2 = normalize(v-e1*dot(e1,v))
-    c = dot(e1, v)/norm(v)
+    e2 = normalize(v - e1 * dot(e1, v))
+    c = dot(e1, normalize(v))
     s = sqrt(1-c^2)
-    P = svd([e1 e2]'; full=true).Vt
+    P = [e1 e2 svd([e1 e2]'; full=true).Vt[StaticArrays.SUnitRange(3,N),:]']
     Q = one(MMatrix{N,N})
     Q[1,1] = c
     Q[1,2] = -s
     Q[2,1] = s
     Q[2,2] = c
-    R = RotMatrix(P'*Q*P)
+    R = RotMatrix(P*Q*P')
     return R
 end

--- a/src/rotation_between.jl
+++ b/src/rotation_between.jl
@@ -1,15 +1,15 @@
 """
-    rotation_between(from, to)
+    rotation_between(u, v)
 
-Compute the quaternion that rotates vector `from` so that it aligns with vector
-`to`, along the geodesic (shortest path).
+Compute the quaternion that rotates vector `u` so that it aligns with vector
+`v`, along the geodesic (shortest path).
 """
-function rotation_between(from::SVector{3}, to::SVector{3})
+function rotation_between(u::SVector{3}, v::SVector{3})
     # Robustified version of implementation from https://www.gamedev.net/topic/429507-finding-the-quaternion-betwee-two-vectors/#entry3856228
-    normprod = sqrt(dot(from, from) * dot(to, to))
+    normprod = sqrt(dot(u, u) * dot(v, v))
     T = typeof(normprod)
     normprod < eps(T) && throw(ArgumentError("Input vectors must be nonzero."))
-    w = normprod + dot(from, to)
-    v = abs(w) < 100 * eps(T) ? perpendicular_vector(from) : cross(from, to)
+    w = normprod + dot(u, v)
+    v = abs(w) < 100 * eps(T) ? perpendicular_vector(u) : cross(u, v)
     @inbounds return QuatRotation(w, v[1], v[2], v[3]) # relies on normalization in constructor
 end

--- a/src/rotation_between.jl
+++ b/src/rotation_between.jl
@@ -21,3 +21,18 @@ function rotation_between(u::SVector{3}, v::SVector{3})
     v = abs(w) < 100 * eps(T) ? perpendicular_vector(u) : cross(u, v)
     @inbounds return QuatRotation(w, v[1], v[2], v[3]) # relies on normalization in constructor
 end
+
+function rotation_between(u::SVector{N}, v::SVector{N}) where N
+    e1 = normalize(u)
+    e2 = normalize(v-e1*dot(e1,v))
+    c = dot(e1, v)/norm(v)
+    s = sqrt(1-c^2)
+    P = svd([e1 e2]'; full=true).Vt
+    Q = one(MMatrix{N,N})
+    Q[1,1] = c
+    Q[1,2] = -s
+    Q[2,1] = s
+    Q[2,2] = c
+    R = RotMatrix(P'*Q*P)
+    return R
+end

--- a/src/rotation_between.jl
+++ b/src/rotation_between.jl
@@ -7,8 +7,8 @@ Compute the quaternion that rotates vector `u` so that it aligns with vector
 function rotation_between end
 
 function rotation_between(u::SVector{2}, v::SVector{2})
-    normprod = sqrt(dot(u, u) * dot(v, v))
-    theta = asin((u[1]*v[2]-u[2]*v[1]) / normprod)
+    c = complex(v[1], v[2]) / complex(u[1], u[2])
+    theta = Base.angle(c)
     return Angle2d(theta)
 end
 

--- a/src/rotation_between.jl
+++ b/src/rotation_between.jl
@@ -4,6 +4,14 @@
 Compute the quaternion that rotates vector `u` so that it aligns with vector
 `v`, along the geodesic (shortest path).
 """
+function rotation_between end
+
+function rotation_between(u::SVector{2}, v::SVector{2})
+    normprod = sqrt(dot(u, u) * dot(v, v))
+    theta = asin((u[1]*v[2]-u[2]*v[1]) / normprod)
+    return Angle2d(theta)
+end
+
 function rotation_between(u::SVector{3}, v::SVector{3})
     # Robustified version of implementation from https://www.gamedev.net/topic/429507-finding-the-quaternion-betwee-two-vectors/#entry3856228
     normprod = sqrt(dot(u, u) * dot(v, v))

--- a/src/rotation_between.jl
+++ b/src/rotation_between.jl
@@ -1,0 +1,15 @@
+"""
+    rotation_between(from, to)
+
+Compute the quaternion that rotates vector `from` so that it aligns with vector
+`to`, along the geodesic (shortest path).
+"""
+function rotation_between(from::SVector{3}, to::SVector{3})
+    # Robustified version of implementation from https://www.gamedev.net/topic/429507-finding-the-quaternion-betwee-two-vectors/#entry3856228
+    normprod = sqrt(dot(from, from) * dot(to, to))
+    T = typeof(normprod)
+    normprod < eps(T) && throw(ArgumentError("Input vectors must be nonzero."))
+    w = normprod + dot(from, to)
+    v = abs(w) < 100 * eps(T) ? perpendicular_vector(from) : cross(from, to)
+    @inbounds return QuatRotation(w, v[1], v[2], v[3]) # relies on normalization in constructor
+end

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -327,8 +327,6 @@ function rotation_between(from::SVector{3}, to::SVector{3})
     @inbounds return QuatRotation(w, v[1], v[2], v[3]) # relies on normalization in constructor
 end
 
-Base.@deprecate rotation_between(from::AbstractVector, to::AbstractVector) rotation_between(SVector{3}(from), SVector{3}(to))
-
 """
     slerp(R1::Rotaion{3}, R2::Rotaion{3}, t::Real)
 

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -312,22 +312,6 @@ Base.:\(q1::QuatRotation, q2::QuatRotation) = inv(q1)*q2
 Base.:/(q1::QuatRotation, q2::QuatRotation) = q1*inv(q2)
 
 """
-    rotation_between(from, to)
-
-Compute the quaternion that rotates vector `from` so that it aligns with vector
-`to`, along the geodesic (shortest path).
-"""
-function rotation_between(from::SVector{3}, to::SVector{3})
-    # Robustified version of implementation from https://www.gamedev.net/topic/429507-finding-the-quaternion-betwee-two-vectors/#entry3856228
-    normprod = sqrt(dot(from, from) * dot(to, to))
-    T = typeof(normprod)
-    normprod < eps(T) && throw(ArgumentError("Input vectors must be nonzero."))
-    w = normprod + dot(from, to)
-    v = abs(w) < 100 * eps(T) ? perpendicular_vector(from) : cross(from, to)
-    @inbounds return QuatRotation(w, v[1], v[2], v[3]) # relies on normalization in constructor
-end
-
-"""
     slerp(R1::Rotaion{3}, R2::Rotaion{3}, t::Real)
 
 Perform spherical linear interpolation (Slerp) between rotations `R1` and `R2`.

--- a/src/unitquaternion.jl
+++ b/src/unitquaternion.jl
@@ -317,7 +317,6 @@ Base.:/(q1::QuatRotation, q2::QuatRotation) = q1*inv(q2)
 Compute the quaternion that rotates vector `from` so that it aligns with vector
 `to`, along the geodesic (shortest path).
 """
-rotation_between(from::AbstractVector, to::AbstractVector) = rotation_between(SVector{3}(from), SVector{3}(to))
 function rotation_between(from::SVector{3}, to::SVector{3})
     # Robustified version of implementation from https://www.gamedev.net/topic/429507-finding-the-quaternion-betwee-two-vectors/#entry3856228
     normprod = sqrt(dot(from, from) * dot(to, to))
@@ -327,6 +326,8 @@ function rotation_between(from::SVector{3}, to::SVector{3})
     v = abs(w) < 100 * eps(T) ? perpendicular_vector(from) : cross(from, to)
     @inbounds return QuatRotation(w, v[1], v[2], v[3]) # relies on normalization in constructor
 end
+
+Base.@deprecate rotation_between(from::AbstractVector, to::AbstractVector) rotation_between(SVector{3}(from), SVector{3}(to))
 
 """
     slerp(R1::Rotaion{3}, R2::Rotaion{3}, t::Real)

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -395,6 +395,18 @@ all_types = (RotMatrix3, RotMatrix{3}, AngleAxis, RotationVec,
             end
         end
     end
+
+    @testset "$(N)-dimensional rotation_between" for N in 2:7
+        for _ in 1:100
+            u = randn(SVector{N})
+            v = randn(SVector{N})
+            R = rotation_between(u,v)
+            @test isrotation(R)
+            @test R isa Rotation
+            @test normalize(v) ≈ R * normalize(u)
+        end
+    end
+
 #########################################################################
     # Check that the eltype is inferred in Rot constructors
     @testset "Rot constructor eltype promotion" begin


### PR DESCRIPTION
This PR fixes https://github.com/JuliaGeometry/Rotations.jl/issues/256.

```julia
julia> using Rotations

julia> using StaticArrays

julia> rotation_between(SVector(1,2,3,5),SVector(1,3,2,5))  # Can be `Rotation{4}`
4×4 RotMatrix{4, Float64, 16} with indices SOneTo(4)×SOneTo(4):
  0.999334  -0.027306  0.023976  -0.00333
  0.023976   0.983017  0.136863   0.11988
 -0.027306  -0.119547  0.983017  -0.13653
 -0.00333   -0.13653   0.11988    0.98335

julia> rotation_between(SVector(3,1),SVector(1,3))  # Can be `Rotation{2}`
2×2 Angle2d{Float64} with indices SOneTo(2)×SOneTo(2)(0.927295):
 0.6  -0.8
 0.8   0.6
```