### PR TITLE
Fix the argument type of `perpendicular_vector`

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -5,7 +5,7 @@ Compute a vector perpendicular to `vec` by switching the two elements with
 largest absolute value, flipping the sign of the second largest, and setting the
 remaining element to zero.
 """
-function perpendicular_vector(vec::SVector{3})
+function perpendicular_vector(vec::StaticVector{3})
     T = eltype(vec)
 
     # find indices of the two elements of vec with the largest absolute values:


### PR DESCRIPTION
This PR fixes #265.

**Before this PR**

```julia
julia> using Rotations, StaticArrays

julia> u = MVector(1,0,0)
3-element MVector{3, Int64} with indices SOneTo(3):
 1
 0
 0

julia> v = MVector(-1,0,0)
3-element MVector{3, Int64} with indices SOneTo(3):
 -1
  0
  0

julia> rotation_between(u,v)
ERROR: MethodError: no method matching perpendicular_vector(::MVector{3, Int64})

Closest candidates are:
  perpendicular_vector(::SVector{3})
   @ Rotations ~/.julia/dev/Rotations/src/util.jl:8

Stacktrace:
 [1] rotation_between(u::MVector{3, Int64}, v::MVector{3, Int64})
   @ Rotations ~/.julia/dev/Rotations/src/rotation_between.jl:23
 [2] top-level scope
   @ REPL[4]:1
```

**After this PR**

```julia
julia> using Rotations, StaticArrays

julia> u = MVector(1,0,0)
3-element MVector{3, Int64} with indices SOneTo(3):
 1
 0
 0

julia> v = MVector(-1,0,0)
3-element MVector{3, Int64} with indices SOneTo(3):
 -1
  0
  0

julia> rotation_between(u,v)
3×3 QuatRotation{Float64} with indices SOneTo(3)×SOneTo(3)(QuaternionF64(0.0, 0.0, 1.0, 0.0)):
 -1.0  0.0   0.0
  0.0  1.0   0.0
  0.0  0.0  -1.0
```