### PR TITLE
Use `sinc` to fix RotationVec near zero

### DIFF
--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -175,7 +175,7 @@ end
 @inline function (::Type{Q})(rv::RotationVec) where Q <: QuatRotation
     theta = rotation_angle(rv)
     if theta < sqrt(eps(typeof(theta)))
-        ϕ = theta / (2π)
+        ϕ = theta / π / 2
         sc = sinc(ϕ) / 2    # this form gracefully handles theta = 0
         qx, qy, qz = sc * rv.sx, sc * rv.sy, sc * rv.sz
         return Q(cos(theta / 2), qx, qy, qz, false)

--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -174,10 +174,16 @@ end
 
 @inline function (::Type{Q})(rv::RotationVec) where Q <: QuatRotation
     theta = rotation_angle(rv)
-    ϕ = theta / (2π)
-    sc = sinc(ϕ) / 2    # this form gracefully handles theta = 0
-    c = cos(theta / 2)
-    return Q(c, sc * rv.sx, sc * rv.sy, sc * rv.sz, false)
+    if theta < sqrt(eps(typeof(theta)))
+        ϕ = theta / (2π)
+        sc = sinc(ϕ) / 2    # this form gracefully handles theta = 0
+        qx, qy, qz = sc * rv.sx, sc * rv.sy, sc * rv.sz
+        return Q(cos(theta / 2), qx, qy, qz, false)
+    else
+        s, c = sincos(theta / 2)
+        sθ = s / theta
+        return Q(c, sθ * rv.sx, sθ * rv.sy, sθ * rv.sz, false)
+    end
 end
 
 (::Type{RV})(q::QuatRotation) where {RV <: RotationVec} = RV(AngleAxis(q))

--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -172,23 +172,17 @@ function (::Type{RV})(aa::AngleAxis) where RV <: RotationVec
     return RV(aa.theta * aa.axis_x, aa.theta * aa.axis_y, aa.theta * aa.axis_z)
 end
 
-function (::Type{Q})(rv::RotationVec) where Q <: QuatRotation
-    return QuatRotation(AngleAxis(rv))
+@inline function (::Type{Q})(rv::RotationVec) where Q <: QuatRotation
+    theta = rotation_angle(rv)
+    ϕ = theta / (2π)
+    sc = sinc(ϕ) / 2    # this form gracefully handles theta = 0
+    c = cos(theta / 2)
+    return Q(c, sc * rv.sx, sc * rv.sy, sc * rv.sz, false)
 end
 
 (::Type{RV})(q::QuatRotation) where {RV <: RotationVec} = RV(AngleAxis(q))
 
-function Base.:*(rv::RotationVec{T1}, v::StaticVector{3, T2}) where {T1,T2}
-    theta = rotation_angle(rv)
-    if (theta > eps(T1)) # use eps here because we have the 1st order series expansion defined
-        return AngleAxis(rv) * v
-    else
-        return similar_type(typeof(v), promote_type(T1,T2))(
-                    v[1] + rv.sy * v[3] - rv.sz * v[2],
-                    v[2] + rv.sz * v[1] - rv.sx * v[3],
-                    v[3] + rv.sx * v[2] - rv.sy * v[1])
-    end
-end
+Base.:*(rv::RotationVec, v::StaticVector{3}) = QuatRotation(rv) * v
 
 @inline Base.:*(rv::RotationVec, r::Rotation) = QuatRotation(rv) * r
 @inline Base.:*(rv::RotationVec, r::RotMatrix) = QuatRotation(rv) * r
@@ -203,7 +197,7 @@ end
 @inline Base.inv(rv::RotationVec) = RotationVec(-rv.sx, -rv.sy, -rv.sz)
 
 # rotation properties
-@inline rotation_angle(rv::RotationVec) = sqrt(rv.sx * rv.sx + rv.sy * rv.sy + rv.sz * rv.sz)
+@inline rotation_angle(rv::RotationVec) = hypot(rv.sx, rv.sy, rv.sz)
 function rotation_axis(rv::RotationVec)     # what should this return for theta = 0?
     theta = rotation_angle(rv)
     return (theta > 0 ? SVector(rv.sx / theta, rv.sy / theta, rv.sz / theta) : SVector(one(theta), zero(theta), zero(theta)))

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -187,7 +187,8 @@ using ForwardDiff
                 v = randn(SVector{3,Float64})
                 rotv(x) = rot(x)*v
                 drotv(x) = ForwardDiff.derivative(rotv, x)
-                @test drotv(0.0) ≈ [0, -v[3], v[2]]
+                # The following broken tests will be fixed by https://github.com/JuliaDiff/ForwardDiff.jl/pull/669
+                @test_broken drotv(0.0) ≈ [0, -v[3], v[2]]
                 @test drotv(1e-20) ≈ [0, -v[3], v[2]]
                 @test_broken ForwardDiff.derivative(drotv, 0.0) ≈ [0, -v[2], -v[3]]
                 @test ForwardDiff.derivative(drotv, 1e-20) ≈ [0, -v[2], -v[3]]

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -180,6 +180,19 @@ using ForwardDiff
                 @test FD_jac ≈ R_jac
             end
         end
+
+        @testset "RotationVec near zero" begin
+            rot(x) = RotationVec(x, 0, 0)
+            for i = 1:10
+                v = randn(SVector{3,Float64})
+                rotv(x) = rot(x)*v
+                drotv(x) = ForwardDiff.derivative(rotv, x)
+                @test drotv(0.0) ≈ [0, -v[3], v[2]]
+                @test drotv(1e-20) ≈ [0, -v[3], v[2]]
+                @test_broken ForwardDiff.derivative(drotv, 0.0) ≈ [0, -v[2], -v[3]]
+                @test ForwardDiff.derivative(drotv, 1e-20) ≈ [0, -v[2], -v[3]]
+            end
+        end
 #=
         # rotate a point by an MRP
         @testset "Jacobian (MRP rotation)" begin

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -334,7 +334,23 @@ all_types = (RotMatrix3, RotMatrix{3}, AngleAxis, RotationVec,
         end
         @test norm(rotation_axis(QuatRotation(1.0, 0.0, 0.0, 0.0))) ≈ 1.0
 
+
         # TODO RotX, RotXY?
+    end
+
+    @testset "RotationVec->QuatRotation, especially near zero" begin
+        for i = 1:10
+            p = rand(RotationVec)
+            all(iszero, Rotations.params(p)) && continue
+            @test QuatRotation(p) ≈ QuatRotation(AngleAxis(p))
+        end
+
+        @test rotation_angle(RotationVec(0.0, 0.0, 0.0)) ≈ 0.0
+        @test rotation_axis(RotationVec(0.0, 0.0, 0.0)) ≈ [1.0, 0.0, 0.0]
+        @test QuatRotation(RotationVec(0.0, 0.0, 0.0)) == QuatRotation(1.0, 0.0, 0.0, 0.0)
+        qr = QuatRotation(RotationVec(2e-30, 0.0, 0.0))
+        @test qr.w ≈ 1
+        @test qr.x ≈ 1e-30
     end
 
     #########################################################################

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -154,8 +154,7 @@ all_types = (RotMatrix3, RotMatrix{3}, AngleAxis, RotationVec,
                 r1 = rand(R)
                 r2 = rand(R)
                 v = @SVector rand(3)
-                @test inv(r1) ≈ adjoint(r1)
-                @test inv(r1) ≈ transpose(r1)
+                @test inv(r1) === adjoint(r1) === transpose(r1)
                 @test inv(r1)*r1 ≈ I
                 @test r1*inv(r1) ≈ I
                 @test r1/r1 ≈ I

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -154,8 +154,8 @@ all_types = (RotMatrix3, RotMatrix{3}, AngleAxis, RotationVec,
                 r1 = rand(R)
                 r2 = rand(R)
                 v = @SVector rand(3)
-                @test inv(r1) == adjoint(r1)
-                @test inv(r1) == transpose(r1)
+                @test inv(r1) ≈ adjoint(r1)
+                @test inv(r1) ≈ transpose(r1)
                 @test inv(r1)*r1 ≈ I
                 @test r1*inv(r1) ≈ I
                 @test r1/r1 ≈ I


### PR DESCRIPTION
By converting straight from RotationVec->QuatRotation,
and using an implementation that exploits `sinc` to handle θ ≈ 0,
we get continuous & differentiable behavior.

Requires https://github.com/JuliaDiff/ForwardDiff.jl/pull/669 before tests will pass.

What this fixes: currently, near the origin the Hessian is zero (which is wrong), because `*(::RotationVec, ::SVector{3})` expands only to linear order. But the fix is aimed at being broader than this specific case (otherwise, we could have just implemented a second-order approximation).

Note: please check whether the relaxation of the `adjoint` test is reasonable, perhaps exact equality is necessary? If so I'll need to come up with a fix.
