### PR TITLE
Fix: rotate a vector of quantities with `AngleAxis`

### DIFF
--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -110,7 +110,7 @@ function Base.:*(aa::AngleAxis, v::StaticVector)
     st, ct = sincos(aa.theta)
     w_cross_pt = cross(w, v)
     m = dot(v, w) * (one(w_cross_pt[1]) - ct)
-    T = promote_type(eltype(aa), eltype(v))
+    T = Base.promote_op(*, eltype(aa), eltype(v))
     return similar_type(v,T)(v[1] * ct + w_cross_pt[1] * st + w[1] * m,
                              v[2] * ct + w_cross_pt[2] * st + w[2] * m,
                              v[3] * ct + w_cross_pt[3] * st + w[3] * m)

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -209,6 +209,29 @@ all_types = (RotMatrix3, RotMatrix{3}, AngleAxis, RotationVec,
         end
     end
 
+    @testset "Rotation result eltype" begin
+        @testset "$(R)" for R in all_types
+            QF64 = typeof(1.0u"m")
+            QF32 = typeof(1.0f0u"m")
+
+            r1 = rand(R{Float64})
+            r2 = rand(R{Float32})
+            v1 = rand(SVector{3,Float64})
+            v2 = rand(SVector{3,Float32})
+            v3 = rand(SVector{3,QF64})
+            v4 = rand(SVector{3,QF32})
+
+            @test eltype(r1*v1) <: Float64
+            @test eltype(r1*v2) <: Float64
+            @test eltype(r1*v3) <: QF64
+            @test eltype(r1*v4) <: QF64
+            @test eltype(r2*v1) <: Float64
+            @test eltype(r2*v2) <: Float32
+            @test eltype(r2*v3) <: QF64
+            @test eltype(r2*v4) <: QF32
+        end
+    end
+
     @testset "Quaternion double cover" begin
         repeats = 100
         Q = QuatRotation

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -210,10 +210,9 @@ all_types = (RotMatrix3, RotMatrix{3}, AngleAxis, RotationVec,
     end
 
     @testset "Rotation result eltype" begin
+        QuantityF64 = typeof(1.0u"m")
+        QuantityF32 = typeof(1.0f0u"m")
         @testset "$(R)" for R in all_types
-            QuantityF64 = typeof(1.0u"m")
-            QuantityF32 = typeof(1.0f0u"m")
-
             r1 = rand(R{Float64})
             r2 = rand(R{Float32})
             v1 = rand(SVector{3,Float64})

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -211,24 +211,24 @@ all_types = (RotMatrix3, RotMatrix{3}, AngleAxis, RotationVec,
 
     @testset "Rotation result eltype" begin
         @testset "$(R)" for R in all_types
-            QF64 = typeof(1.0u"m")
-            QF32 = typeof(1.0f0u"m")
+            QuantityF64 = typeof(1.0u"m")
+            QuantityF32 = typeof(1.0f0u"m")
 
             r1 = rand(R{Float64})
             r2 = rand(R{Float32})
             v1 = rand(SVector{3,Float64})
             v2 = rand(SVector{3,Float32})
-            v3 = rand(SVector{3,QF64})
-            v4 = rand(SVector{3,QF32})
+            v3 = rand(SVector{3,QuantityF64})
+            v4 = rand(SVector{3,QuantityF32})
 
             @test eltype(r1*v1) <: Float64
             @test eltype(r1*v2) <: Float64
-            @test eltype(r1*v3) <: QF64
-            @test eltype(r1*v4) <: QF64
+            @test eltype(r1*v3) <: QuantityF64
+            @test eltype(r1*v4) <: QuantityF64
             @test eltype(r2*v1) <: Float64
             @test eltype(r2*v2) <: Float32
-            @test eltype(r2*v3) <: QF64
-            @test eltype(r2*v4) <: QF32
+            @test eltype(r2*v3) <: QuantityF64
+            @test eltype(r2*v4) <: QuantityF32
         end
     end
 


### PR DESCRIPTION
In the current version of Rotations.jl, rotating a vector of quantities with `AngleAxis` returns a new vector with incorrect eltype:
```julia
julia> R = AngleAxis(π / 2, 0, 0, 1)
3×3 AngleAxis{Float64} with indices SOneTo(3)×SOneTo(3)(1.5708, 0.0, 0.0, 1.0):
 2.22045e-16  -1.0          0.0
 1.0           2.22045e-16  0.0
 0.0           0.0          1.0

julia> v = SVector(1.0, 1.0, 1.0) * u"m"
3-element SVector{3, Quantity{Float64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}} with indices SOneTo(3):
 1.0 m
 1.0 m
 1.0 m

julia> R * v
3-element SVector{3, Quantity{Float64}} with indices SOneTo(3):
 -0.9999999999999999 m
                 1.0 m
                 1.0 m
```
This PR fixes this bug:
```julia
julia> R = AngleAxis(π / 2, 0, 0, 1)
3×3 AngleAxis{Float64} with indices SOneTo(3)×SOneTo(3)(1.5708, 0.0, 0.0, 1.0):
 2.22045e-16  -1.0          0.0
 1.0           2.22045e-16  0.0
 0.0           0.0          1.0

julia> v = SVector(1.0, 1.0, 1.0) * u"m"
3-element SVector{3, Quantity{Float64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}} with indices SOneTo(3):
 1.0 m
 1.0 m
 1.0 m

julia> R * v
3-element SVector{3, Quantity{Float64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}} with indices SOneTo(3):
 -0.9999999999999999 m
                 1.0 m
                 1.0 m
```